### PR TITLE
Add get_algebra_basis(): concrete matrix bases for the classified DLA (#200)

### DIFF
--- a/docs/source/user/classification.rst
+++ b/docs/source/user/classification.rst
@@ -118,6 +118,48 @@ Also measures of operator spread complexity rely on this concept.
 Furthermore, determining moments of circuits can be significantly simplified when the Lie algebra is known.
 All these applications are functionalities of :code:`paulie`.
 
+From algebra label to matrix basis
+----------------------------------
+:code:`get_algebra` returns the isomorphism *label* of the dynamical Lie algebra,
+which is enough to tell apart algebras up to isomorphism but cannot be
+multiplied, exponentiated, or commuted with anything. The companion method
+:code:`get_algebra_basis` returns the algebra as a concrete set of matrix
+generators in the defining representation, partitioned by direct summand.
+
+Reusing the two examples above, the single-summand B-type case
+
+.. code-block:: python
+
+    n_qubits = 4
+    generators = p(["XY", "XZ"], n=n_qubits)
+    basis = generators.get_algebra_basis()
+    print(f"summands = {len(basis)}, shape per summand = {basis[0].shape}")
+
+outputs
+
+.. code-block:: bash
+
+    summands = 1, shape per summand = (36, 8, 8)
+
+reflecting that :math:`\mathfrak{sp}(4)` has dimension :math:`4 \cdot (2 \cdot 4 + 1) = 36`
+and acts on an :math:`8`-dimensional space. The direct-sum A-type example
+
+.. code-block:: python
+
+    generators = p(["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"])
+    basis = generators.get_algebra_basis()
+    print(f"summands = {len(basis)}, shape per summand = {basis[0].shape}")
+
+outputs
+
+.. code-block:: bash
+
+    summands = 4, shape per summand = (10, 5, 5)
+
+matching :math:`4 \cdot \mathfrak{so}(5)` with :math:`\dim \mathfrak{so}(5) = 10`.
+Each entry of the returned list is one full summand basis; the generators of
+different summands have disjoint supports when embedded in the full direct sum.
+
 
 
 

--- a/src/paulie/application/algebra_basis.py
+++ b/src/paulie/application/algebra_basis.py
@@ -1,0 +1,269 @@
+"""
+Matrix bases for the classical Lie algebras :math:`\\mathfrak{u}(N)`,
+:math:`\\mathfrak{su}(N)`, :math:`\\mathfrak{so}(N)` and :math:`\\mathfrak{sp}(N)`
+in their defining representations.
+
+The functions exposed here produce a list of generators that span the named
+Lie algebra. Each generator is a square NumPy array; the full basis is
+returned as a stack of shape ``(dim, M, M)`` where ``dim`` is the algebra's
+dimension and ``M`` is the defining-representation matrix size.
+
+These primitives are consumed by :meth:`Classification.get_algebra_basis`
+and :meth:`PauliStringCollection.get_algebra_basis`, which turn an
+isomorphism label like ``"4*so(5)"`` into the concrete matrices a user
+needs for Cartan decompositions, structure-constant computations, or any
+downstream task that requires the algebra as a mathematical object rather
+than a name.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def so_basis(n: int) -> np.ndarray:
+    r"""
+    Basis of :math:`\mathfrak{so}(n)` in its defining representation.
+
+    :math:`\mathfrak{so}(n)` consists of the real antisymmetric
+    :math:`n \times n` matrices. The basis returned here is the
+    standard one made from the matrix units
+    :math:`E_{ij}` (one at row :math:`i`, column :math:`j`, zero
+    elsewhere):
+
+    .. math::
+
+        T_{(i,j)} = E_{ij} - E_{ji}, \qquad 0 \le i < j < n.
+
+    There are :math:`\binom{n}{2} = n(n-1)/2` such generators, which is
+    the dimension of :math:`\mathfrak{so}(n)`. They satisfy
+    :math:`T^\top = -T`, span the real antisymmetric matrices, and the
+    bracket :math:`[T_{(i,j)}, T_{(k,l)}]` is again real antisymmetric so
+    the algebra closes.
+
+    Args:
+        n: Matrix size of the defining representation. ``n >= 1``.
+           ``n == 1`` returns an empty basis (the trivial algebra).
+
+    Returns:
+        np.ndarray: Real array of shape ``(n*(n-1)//2, n, n)``.
+
+    Examples:
+        >>> from paulie.application.algebra_basis import so_basis
+        >>> b = so_basis(3)
+        >>> b.shape
+        (3, 3, 3)
+        >>> # Antisymmetry of every generator
+        >>> import numpy as np
+        >>> np.allclose(b + b.swapaxes(1, 2), 0)
+        True
+
+    References:
+        Hall, B. C. *Lie Groups, Lie Algebras, and Representations*,
+        2nd ed., Springer (2015), Section 3.4.
+    """
+    if n < 1:
+        raise ValueError(f"n must be >= 1, got {n}")
+    dim = n * (n - 1) // 2
+    out = np.zeros((dim, n, n), dtype=np.float64)
+    idx = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            out[idx, i, j] = 1.0
+            out[idx, j, i] = -1.0
+            idx += 1
+    return out
+
+
+def sp_basis(n: int) -> np.ndarray:
+    r"""
+    Basis of :math:`\mathfrak{sp}(n)` in its defining representation.
+
+    Following the convention used elsewhere in PauLie (consistent with
+    :cite:t:`Aguilar_2024`), :math:`\mathfrak{sp}(n)` denotes the
+    rank-:math:`n` real symplectic algebra. Its defining representation
+    acts on :math:`\mathbb{R}^{2n}` by :math:`2n \times 2n` matrices
+    :math:`M` satisfying
+
+    .. math::
+
+        M^\top J + J M = 0, \qquad
+        J = \begin{pmatrix} 0 & I_n \\ -I_n & 0 \end{pmatrix}.
+
+    Writing :math:`M` in block form
+    :math:`\begin{pmatrix} A & B \\ C & -A^\top \end{pmatrix}` with
+    :math:`A` arbitrary and :math:`B, C` symmetric :math:`n \times n`
+    blocks gives :math:`n^2 + n(n+1) = n(2n+1)` real parameters, which
+    is the dimension of :math:`\mathfrak{sp}(n)`. The basis returned
+    here exposes each parameter as a separate generator: the :math:`n^2`
+    "A-type" generators come first, followed by the :math:`n(n+1)/2`
+    "B-type" generators and the :math:`n(n+1)/2` "C-type" generators.
+
+    Args:
+        n: Rank of the symplectic algebra. ``n >= 1``. Matrices have
+           shape ``(2n, 2n)``.
+
+    Returns:
+        np.ndarray: Real array of shape ``(n*(2n+1), 2n, 2n)``.
+
+    Examples:
+        >>> from paulie.application.algebra_basis import sp_basis
+        >>> b = sp_basis(1)
+        >>> b.shape           # dim sp(1) = 3, matrices 2x2
+        (3, 2, 2)
+        >>> # Defining condition: M^T J + J M = 0
+        >>> import numpy as np
+        >>> J = np.array([[0, 1], [-1, 0]], dtype=float)
+        >>> np.allclose(b.swapaxes(1, 2) @ J + J @ b, 0)
+        True
+
+    References:
+        Hall, B. C. *Lie Groups, Lie Algebras, and Representations*,
+        2nd ed., Springer (2015), Section 3.4 (Example 4).
+    """
+    if n < 1:
+        raise ValueError(f"n must be >= 1, got {n}")
+    matrix_size = 2 * n
+    dim = n * (2 * n + 1)
+    out = np.zeros((dim, matrix_size, matrix_size), dtype=np.float64)
+    idx = 0
+
+    # A-block: n*n arbitrary generators. M placed at (i, j) of upper-left
+    # block forces -1 at (n+j, n+i) of lower-right to keep -A^T relation.
+    for i in range(n):
+        for j in range(n):
+            out[idx, i, j] = 1.0
+            out[idx, n + j, n + i] = -1.0
+            idx += 1
+
+    # B-block: symmetric n*n in the upper-right corner.
+    for i in range(n):
+        for j in range(i, n):
+            out[idx, i, n + j] = 1.0
+            if i != j:
+                out[idx, j, n + i] = 1.0
+            idx += 1
+
+    # C-block: symmetric n*n in the lower-left corner.
+    for i in range(n):
+        for j in range(i, n):
+            out[idx, n + i, j] = 1.0
+            if i != j:
+                out[idx, n + j, i] = 1.0
+            idx += 1
+
+    return out
+
+
+def su_basis(n: int) -> np.ndarray:
+    r"""
+    Basis of :math:`\mathfrak{su}(n)` in its defining representation.
+
+    :math:`\mathfrak{su}(n)` consists of the traceless anti-Hermitian
+    :math:`n \times n` complex matrices. The basis returned here is
+    constructed from generalised Gell-Mann matrices, each multiplied by
+    :math:`i` so the generators are anti-Hermitian (this matches the
+    physics convention :math:`U = \exp(iH) \in \mathrm{SU}(n)` with
+    Hermitian :math:`H`, viewed as the Lie algebra element :math:`iH`):
+
+    - **Symmetric off-diagonal**, for :math:`j < k`:
+      :math:`i(\lvert j\rangle\!\langle k\rvert + \lvert k\rangle\!\langle j\rvert)`.
+    - **Antisymmetric off-diagonal**, for :math:`j < k`:
+      :math:`\lvert j\rangle\!\langle k\rvert - \lvert k\rangle\!\langle j\rvert`.
+    - **Diagonal traceless**, for :math:`0 \le m < n-1`:
+      :math:`i\bigl(\lvert m\rangle\!\langle m\rvert - \lvert m+1\rangle\!\langle m+1\rvert\bigr)`.
+
+    Total: :math:`n^2 - 1` generators, matching
+    :math:`\dim \mathfrak{su}(n)`. The diagonal generators are NOT
+    orthonormalised; they are linearly independent, which is enough for
+    a basis.
+
+    Args:
+        n: Matrix size of the defining representation. ``n >= 1``.
+           ``n == 1`` returns an empty basis (since :math:`\mathfrak{su}(1) = 0`).
+
+    Returns:
+        np.ndarray: Complex array of shape ``(n*n - 1, n, n)``.
+
+    Examples:
+        >>> from paulie.application.algebra_basis import su_basis
+        >>> b = su_basis(2)
+        >>> b.shape           # 3 Pauli-like generators
+        (3, 2, 2)
+        >>> # Anti-Hermitian and traceless
+        >>> import numpy as np
+        >>> np.allclose(b + b.conj().swapaxes(1, 2), 0)
+        True
+        >>> np.allclose(np.trace(b, axis1=1, axis2=2), 0)
+        True
+
+    References:
+        Georgi, H. *Lie Algebras in Particle Physics*, 2nd ed.,
+        Westview Press (1999), Chapter 1; generalised Gell-Mann matrices
+        also discussed in Bertlmann & Krammer, J. Phys. A 41, 235303
+        (2008).
+    """
+    if n < 1:
+        raise ValueError(f"n must be >= 1, got {n}")
+    dim = n * n - 1
+    out = np.zeros((dim, n, n), dtype=np.complex128)
+    idx = 0
+
+    # Symmetric off-diagonal: i*(|j><k| + |k><j|)
+    for j in range(n):
+        for k in range(j + 1, n):
+            out[idx, j, k] = 1j
+            out[idx, k, j] = 1j
+            idx += 1
+
+    # Antisymmetric off-diagonal: |j><k| - |k><j|
+    for j in range(n):
+        for k in range(j + 1, n):
+            out[idx, j, k] = 1.0
+            out[idx, k, j] = -1.0
+            idx += 1
+
+    # Diagonal traceless: i*(|m><m| - |m+1><m+1|)
+    for m in range(n - 1):
+        out[idx, m, m] = 1j
+        out[idx, m + 1, m + 1] = -1j
+        idx += 1
+
+    return out
+
+
+def u_basis(n: int) -> np.ndarray:
+    r"""
+    Basis of :math:`\mathfrak{u}(n)` in its defining representation.
+
+    :math:`\mathfrak{u}(n) = \mathfrak{su}(n) \oplus \mathfrak{u}(1)`,
+    i.e. the anti-Hermitian :math:`n \times n` complex matrices. The
+    basis returned here is :func:`su_basis` extended by the additional
+    central generator :math:`i I_n`, giving :math:`n^2` matrices total.
+
+    Args:
+        n: Matrix size of the defining representation. ``n >= 1``.
+
+    Returns:
+        np.ndarray: Complex array of shape ``(n*n, n, n)``.
+
+    Examples:
+        >>> from paulie.application.algebra_basis import u_basis
+        >>> b = u_basis(1)            # u(1) = iR
+        >>> b.shape
+        (1, 1, 1)
+        >>> b[0, 0, 0]                # generator is i
+        1j
+        >>> import numpy as np
+        >>> np.allclose(b + b.conj().swapaxes(1, 2), 0)  # anti-Hermitian
+        True
+
+    References:
+        Hall, B. C. *Lie Groups, Lie Algebras, and Representations*,
+        2nd ed., Springer (2015), Section 1.2.
+    """
+    if n < 1:
+        raise ValueError(f"n must be >= 1, got {n}")
+    su = su_basis(n)
+    central = (1j * np.eye(n, dtype=np.complex128))[np.newaxis, ...]
+    return np.concatenate([su, central], axis=0)

--- a/src/paulie/classifier/classification.py
+++ b/src/paulie/classifier/classification.py
@@ -4,6 +4,14 @@
 import enum
 from collections.abc import Generator
 
+import numpy as np
+
+from paulie.application.algebra_basis import (
+    so_basis,
+    sp_basis,
+    su_basis,
+    u_basis,
+)
 from paulie.common.pauli_string_bitarray import PauliString
 
 
@@ -382,6 +390,64 @@ class Classification:
             else:
                 algebras[algebra] = nc if nc == 1 else 2**(nc-1)
         return "+".join([key if v == 1 else str(v) + "*" + key for key, v in algebras.items()])
+
+    def get_algebra_basis(self) -> list[np.ndarray]:
+        r"""
+        Get the dynamical Lie algebra as a list of matrix bases, one entry per
+        direct summand.
+
+        Whereas :meth:`get_algebra` returns the isomorphism *label* of the algebra
+        (e.g. ``"4*so(5)"``), this method returns the actual generators of each
+        summand in its defining representation, as ``numpy`` arrays. The list has
+        length equal to the total number of summands implied by the label:
+        ``len(basis)`` for ``"4*so(5)"`` is ``4``, and each entry is a stack of
+        shape ``(10, 5, 5)`` (since :math:`\dim \mathfrak{so}(5) = 10`).
+
+        Each summand's generators satisfy the defining property of its algebra:
+        anti-symmetry for :math:`\mathfrak{so}`, the symplectic relation
+        :math:`M^\top J + J M = 0` for :math:`\mathfrak{sp}`, and anti-Hermiticity
+        (plus tracelessness for :math:`\mathfrak{su}`) for
+        :math:`\mathfrak{su}` / :math:`\mathfrak{u}`.
+
+        Conventions (matching :func:`paulie.application.algebra_basis.so_basis`,
+        :func:`paulie.application.algebra_basis.sp_basis`,
+        :func:`paulie.application.algebra_basis.su_basis`,
+        :func:`paulie.application.algebra_basis.u_basis`):
+
+        - :math:`\mathfrak{so}(N)`: real antisymmetric :math:`N \times N` matrices
+          :math:`E_{ij} - E_{ji}` for :math:`i < j`. Dim :math:`N(N-1)/2`.
+        - :math:`\mathfrak{sp}(N)`: rank-:math:`N` symplectic, acting as
+          :math:`2N \times 2N` matrices satisfying :math:`M^\top J + JM = 0` with
+          :math:`J = \begin{pmatrix} 0 & I_N \\ -I_N & 0 \end{pmatrix}`. Dim
+          :math:`N(2N+1)`.
+        - :math:`\mathfrak{su}(N)`: traceless anti-Hermitian :math:`N \times N`.
+          Built from the generalised Gell-Mann matrices. Dim :math:`N^2 - 1`.
+        - :math:`\mathfrak{u}(N)`: :math:`\mathfrak{su}(N)` plus the central
+          generator :math:`i I_N`. Dim :math:`N^2`.
+
+        Returns:
+            list[np.ndarray]: One entry per summand. Each entry has shape
+            ``(dim, M, M)`` where ``dim`` is the algebra's dimension and ``M``
+            its defining-representation matrix size. Real dtype for
+            :math:`\mathfrak{so}` and :math:`\mathfrak{sp}`, complex for
+            :math:`\mathfrak{su}` and :math:`\mathfrak{u}`.
+        """
+        out: list[np.ndarray] = []
+        for morph in self.morphs:
+            type_algebra, nc, size = morph.get_algebra_properties()
+            multiplicity = nc if nc == 1 else 2**(nc - 1)
+            if type_algebra == TypeAlgebra.SO:
+                summand = so_basis(size)
+            elif type_algebra == TypeAlgebra.SP:
+                summand = sp_basis(size)
+            elif type_algebra == TypeAlgebra.SU:
+                summand = su_basis(size)
+            elif type_algebra == TypeAlgebra.U:
+                summand = u_basis(size)
+            else:
+                continue
+            out.extend(summand for _ in range(multiplicity))
+        return out
 
     def contains_algebra(self, algebra:str) -> bool:
         """

--- a/src/paulie/common/pauli_string_collection.py
+++ b/src/paulie/common/pauli_string_collection.py
@@ -570,6 +570,30 @@ class PauliStringCollection:
         classification = self.get_class()
         return str(classification.get_algebra())
 
+    def get_algebra_basis(self) -> list:
+        r"""
+        Get the matrix-basis form of the dynamical Lie algebra named by
+        :meth:`get_algebra`.
+
+        See :meth:`paulie.classifier.classification.Classification.get_algebra_basis`
+        for the full specification. The returned list has one entry per direct
+        summand; each entry is a ``numpy`` array of shape ``(dim, M, M)``
+        containing the defining-representation generators of that summand.
+
+        Returns:
+            list[np.ndarray]: One matrix basis per summand of the algebra.
+
+        Examples:
+            >>> from paulie import get_pauli_string as p
+            >>> basis = p(["XY"], n=3).get_algebra_basis()
+            >>> len(basis)                       # so(3) has 1 summand
+            1
+            >>> basis[0].shape                   # dim so(3) = 3, 3x3 matrices
+            (3, 3, 3)
+        """
+        classification = self.get_class()
+        return classification.get_algebra_basis()
+
     def is_algebra(self, algebra: str) -> bool:
         """
         Checks whether the classified algebra is equal to the given algebra.

--- a/tests/test_algebra_basis.py
+++ b/tests/test_algebra_basis.py
@@ -1,0 +1,213 @@
+"""
+Tests for the matrix-basis form of the classified Lie algebra.
+
+Covers:
+- The four single-algebra primitive bases (so, sp, su, u): defining
+  property, dimension, real/complex dtype, bracket closure.
+- The Classification / PauliStringCollection ``get_algebra_basis`` entry
+  points: one canonical-type input per family plus one direct-sum input.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from paulie import G_LIE, get_pauli_string as p
+from paulie.application.algebra_basis import (
+    so_basis,
+    sp_basis,
+    su_basis,
+    u_basis,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+TOL = 1e-10
+
+
+def _is_antisym_real(b: np.ndarray) -> bool:
+    return bool(np.allclose(b + b.swapaxes(1, 2), 0, atol=TOL))
+
+
+def _is_anti_hermitian(b: np.ndarray) -> bool:
+    return bool(np.allclose(b + b.conj().swapaxes(1, 2), 0, atol=TOL))
+
+
+def _is_traceless(b: np.ndarray) -> bool:
+    return bool(np.allclose(np.trace(b, axis1=1, axis2=2), 0, atol=TOL))
+
+
+def _is_symplectic_generator(b: np.ndarray) -> bool:
+    """Check M^T J + J M = 0 for all generators in the stack."""
+    n2 = b.shape[1]
+    assert n2 % 2 == 0
+    n = n2 // 2
+    j_mat = np.zeros((n2, n2), dtype=b.dtype)
+    j_mat[:n, n:] = np.eye(n)
+    j_mat[n:, :n] = -np.eye(n)
+    return bool(np.allclose(b.swapaxes(1, 2) @ j_mat + j_mat @ b, 0, atol=TOL))
+
+
+def _linearly_independent(b: np.ndarray) -> bool:
+    flat = b.reshape(b.shape[0], -1)
+    return int(np.linalg.matrix_rank(flat)) == b.shape[0]
+
+
+def _brackets_in_span(b: np.ndarray) -> bool:
+    """Every pairwise commutator lies in span(b)."""
+    flat = b.reshape(b.shape[0], -1)
+    dim = b.shape[0]
+    for i in range(dim):
+        for j in range(i + 1, dim):
+            comm = (b[i] @ b[j] - b[j] @ b[i]).reshape(-1)
+            stacked = np.concatenate([flat, comm[np.newaxis]], axis=0)
+            if np.linalg.matrix_rank(stacked) != dim:
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Primitive bases
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("n", [2, 3, 4, 5])
+def test_so_basis_defining_property(n: int) -> None:
+    """so(n) generators are real antisymmetric and have dim n(n-1)/2."""
+    b = so_basis(n)
+    assert b.shape == (n * (n - 1) // 2, n, n)
+    assert b.dtype == np.float64
+    assert _is_antisym_real(b)
+    assert _linearly_independent(b)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_sp_basis_defining_property(n: int) -> None:
+    """sp(n) generators (rank n, 2n*2n matrices) satisfy M^T J + J M = 0
+    and have dim n(2n+1)."""
+    b = sp_basis(n)
+    assert b.shape == (n * (2 * n + 1), 2 * n, 2 * n)
+    assert b.dtype == np.float64
+    assert _is_symplectic_generator(b)
+    assert _linearly_independent(b)
+
+
+@pytest.mark.parametrize("n", [2, 3, 4])
+def test_su_basis_defining_property(n: int) -> None:
+    """su(n) generators are traceless anti-Hermitian, dim n^2 - 1."""
+    b = su_basis(n)
+    assert b.shape == (n * n - 1, n, n)
+    assert b.dtype == np.complex128
+    assert _is_anti_hermitian(b)
+    assert _is_traceless(b)
+    assert _linearly_independent(b)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_u_basis_defining_property(n: int) -> None:
+    """u(n) generators are anti-Hermitian (NOT traceless), dim n^2."""
+    b = u_basis(n)
+    assert b.shape == (n * n, n, n)
+    assert b.dtype == np.complex128
+    assert _is_anti_hermitian(b)
+    assert _linearly_independent(b)
+
+
+@pytest.mark.parametrize(
+    "ctor,n",
+    [
+        (so_basis, 4),
+        (sp_basis, 2),
+        (su_basis, 3),
+        (u_basis, 2),
+    ],
+)
+def test_brackets_close(ctor, n: int) -> None:
+    """For each primitive basis, every commutator lies in the span."""
+    assert _brackets_in_span(ctor(n))
+
+
+def test_su_1_is_trivial() -> None:
+    """su(1) is the zero algebra."""
+    assert su_basis(1).shape == (0, 1, 1)
+
+
+def test_invalid_n_rejected() -> None:
+    """All constructors reject n < 1."""
+    with pytest.raises(ValueError):
+        so_basis(0)
+    with pytest.raises(ValueError):
+        sp_basis(0)
+    with pytest.raises(ValueError):
+        su_basis(0)
+    with pytest.raises(ValueError):
+        u_basis(0)
+
+
+# ---------------------------------------------------------------------------
+# get_algebra_basis end-to-end on classified inputs
+# ---------------------------------------------------------------------------
+def test_get_algebra_basis_so() -> None:
+    """A canonical so(3) input — one summand of dim 3, 3x3 antisymmetric."""
+    collection = p(["XY"], n=3)
+    assert collection.get_algebra() == "so(3)"
+    basis = collection.get_algebra_basis()
+    assert len(basis) == 1
+    assert basis[0].shape == (3, 3, 3)
+    assert _is_antisym_real(basis[0])
+
+
+def test_get_algebra_basis_sp() -> None:
+    """A canonical sp(4) input — one summand of dim 4*(2*4+1) = 36, 8x8."""
+    collection = p(["XY", "XZ"], n=4)
+    assert collection.get_algebra() == "sp(4)"
+    basis = collection.get_algebra_basis()
+    assert len(basis) == 1
+    assert basis[0].shape == (36, 8, 8)
+    assert _is_symplectic_generator(basis[0])
+
+
+def test_get_algebra_basis_u_singleton() -> None:
+    """A single Pauli string generates u(1)."""
+    collection = p(["XY"])
+    assert collection.get_algebra() == "u(1)"
+    basis = collection.get_algebra_basis()
+    assert len(basis) == 1
+    assert basis[0].shape == (1, 1, 1)
+    assert _is_anti_hermitian(basis[0])
+
+
+def test_get_algebra_basis_direct_sum() -> None:
+    """A canonical direct-sum input — paulie reports '4*so(5)', so we expect
+    4 summands each of shape (10, 5, 5)."""
+    collection = p(["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"])
+    assert collection.get_algebra() == "4*so(5)"
+    basis = collection.get_algebra_basis()
+    assert len(basis) == 4
+    for summand in basis:
+        assert summand.shape == (10, 5, 5)
+        assert _is_antisym_real(summand)
+
+
+def test_get_algebra_basis_brackets_close_per_summand() -> None:
+    """Bracket closure spot-check on a direct-sum input: each summand is a
+    Lie algebra in its own right, so commutators must stay in the summand."""
+    basis = p(["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"]).get_algebra_basis()
+    # Spot-check the first summand to keep the test fast.
+    assert _brackets_in_span(basis[0])
+
+
+def test_get_algebra_basis_su() -> None:
+    """A canonical su(16) input from the G_LIE tabulated generators.
+
+    a12 at n=4 produces a single su(16) summand. Its dim is
+    :math:`16^2 - 1 = 255`, with 16x16 anti-Hermitian traceless matrices.
+    """
+    collection = p(G_LIE["a12"], n=4)
+    assert collection.get_algebra() == "su(16)"
+    basis = collection.get_algebra_basis()
+    assert len(basis) == 1
+    assert basis[0].shape == (255, 16, 16)
+    assert _is_anti_hermitian(basis[0])
+    assert _is_traceless(basis[0])


### PR DESCRIPTION
Closes #200.

## What this adds

`get_algebra_basis()` — the companion to `get_algebra()` that the issue asks for. Where `get_algebra()` returns the label `"4*so(5)"`, `get_algebra_basis()` returns a list of numpy arrays — one per direct summand — each of shape `(dim, M, M)` containing the defining-representation generators.

Primitive constructors live in a new module `src/paulie/application/algebra_basis.py`:

| Function | Algebra | Shape | dtype |
|---|---|---|---|
| `so_basis(N)` | real antisymmetric `E_ij − E_ji` | `(N(N-1)/2, N, N)` | float64 |
| `sp_basis(N)` | rank-N symplectic, `MᵀJ + JM = 0` | `(N(2N+1), 2N, 2N)` | float64 |
| `su_basis(N)` | traceless anti-Hermitian (generalised Gell-Mann × i) | `(N²-1, N, N)` | complex128 |
| `u_basis(N)` | `su(N) ⊕ iI_N` | `(N², N, N)` | complex128 |

`Classification.get_algebra_basis()` assembles per-summand bases using the existing `TypeAlgebra` / multiplicity tally, and `PauliStringCollection.get_algebra_basis()` proxies through.

## Acceptance criteria coverage

- ✅ `get_algebra_basis` exposed at the same level as `get_algebra` (on both `Classification` and `PauliStringCollection`).
- ✅ Returns the corresponding defining-rep matrix basis, partitioned by summand.
- ✅ `len(basis)` equals the number of summands implied by the label.
- ✅ Dimensions match the issue's formulas (`so` → `N(N-1)/2`, `sp` → `N(2N+1)`, `su` → `N²-1`).
- ✅ Defining condition verified to 1e-10 (antisymmetric / symplectic / anti-Hermitian).
- ✅ Bracket closure spot-checked in tests.
- ✅ Convention documented in each docstring (Google style with `Examples` and `References` sections).
- ✅ Unit tests cover one input per canonical type (`so`, `sp`, `su`, `u`) plus a direct-sum input (`4*so(5)`).
- ✅ `docs/source/user/classification.rst` extended with a short "From algebra label to matrix basis" section reusing the two examples already on the page.

## Verification

```
$ uv run python -m pytest -q
864 passed in 6.38s     # 839 existing + 25 new
$ uv run ruff check src/paulie/application/algebra_basis.py \
                    src/paulie/classifier/classification.py \
                    src/paulie/common/pauli_string_collection.py \
                    tests/test_algebra_basis.py
All checks passed!
```

`mypy` is clean on the new code (`algebra_basis.py` has zero errors); the pre-existing mypy errors elsewhere in the repo are unchanged.

## On the `sp` convention

The issue's `dim sp(N) = N(2N+1)` formula corresponds to interpreting `N` as the **rank** (i.e. `sp(N)` acts on `R^{2N}` via `2N × 2N` matrices). This matches what `paulie` already reports — `p(["XY","XZ"], n=4).get_algebra() == "sp(4)"` would otherwise refer to a `4×4` symplectic, which doesn't exist (smallest is `sp(2,R) = 2×2`). Documented in the `sp_basis` docstring; happy to flip the convention if the maintainers prefer matrix-size labeling.

---

I used Claude Code (Opus 4.7) to help brainstorm the logic for the `sp_basis` block decomposition and the docstring math, which I then manually verified by checking the defining condition `MᵀJ + JM = 0` and running the bracket-closure tests locally.
