### PR TITLE
  feat: observer-based recording and stable animation for the canonicalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ xcuserdata/
 # Doc-build generated files
 docs/_build/
 docs/source/**/generated/
+docs/source/media/example_c.html
+docs/source/media/example_d.html
+docs/preview/
 
 #Python modules
 MANIFEST

--- a/docs/generate_animations.py
+++ b/docs/generate_animations.py
@@ -1,0 +1,62 @@
+"""
+Generate preview media for the classification animations.
+
+Produces, for each worked example, an interactive HTML player, an animated GIF, and a still
+PNG of every frame. Run with `uv run python docs/generate_animations.py`. The interactive
+players embedded in the documentation are generated automatically at build time by
+`docs/source/conf.py`; this script is a convenience for previewing the media locally.
+"""
+import re
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+
+from paulie import animation_anti_commutation_graph, get_pauli_string as p  # pylint: disable=wrong-import-position
+from paulie.application.animation import _build_record  # pylint: disable=wrong-import-position
+
+OUT = Path(__file__).resolve().parent / "preview"
+
+EXAMPLES = {
+    "example_c": p(["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"]),
+    "example_d": p(["XY", "XZ"], n=4),
+}
+
+
+def _slug(title: str) -> str:
+    """
+    Turn a frame title into a filename-safe slug.
+
+    Args:
+        title (str): Frame title.
+    Returns:
+        str: Filename-safe slug.
+    """
+    return re.sub(r"[^0-9a-zA-Z]+", "_", title).strip("_").lower()
+
+
+def main() -> None:
+    """
+    Generate an HTML player, a GIF, and per-frame PNG stills for each example.
+
+    Returns:
+        None
+    """
+    OUT.mkdir(exist_ok=True)
+    for name, generators in EXAMPLES.items():
+        anim = animation_anti_commutation_graph(generators, interval=1200)
+        # Interactive HTML player with play / pause / step / frame slider controls.
+        (OUT / f"{name}.html").write_text(anim.to_jshtml(default_mode="loop"), encoding="utf-8")
+        # Animated GIF.
+        anim.save(str(OUT / f"{name}.gif"), writer="pillow", fps=1)
+        # Still PNG of every frame, named by index and title.
+        record = _build_record(generators)
+        for i in range(record.get_size()):
+            anim._func(i)  # pylint: disable=protected-access
+            anim._fig.savefig(  # pylint: disable=protected-access
+                OUT / f"{name}_{i:02d}_{_slug(record.get_frame(i).get_title())}.png", dpi=150)
+        print(f"{name}: {record.get_size()} frames -> {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/api/paulie.application.rst
+++ b/docs/source/api/paulie.application.rst
@@ -11,6 +11,7 @@ Utilities for visualizing the anti-commutation graph.
    :toctree: generated/
 
    plot.plot_anti_commutation_graph
+   animation.animation_anti_commutation_graph
 
 Average Pauli weight
 --------------------

--- a/docs/source/api/paulie.classifier.rst
+++ b/docs/source/api/paulie.classifier.rst
@@ -14,6 +14,7 @@ Utilities for classifying the DLA of a set of Pauli strings.
    classification.Morph
    classification.TypeAlgebra
    classification.TypeGraph
+   recording_canonicalizer.RecordingCanonicalizer
 
 Exceptions
 ----------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,9 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../'))
 
+import matplotlib  # pylint: disable=wrong-import-position
+matplotlib.use("Agg")  # Render animations headless during the documentation build.
+
 from intersphinx_registry import get_intersphinx_mapping  # pylint: disable=wrong-import-position
 
 project = 'paulie'
@@ -60,3 +63,45 @@ html_static_path = ['_static']
 html_css_files = ['custom.css']
 mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js'
 html_extra_path=['media']
+
+
+# -- Classification animations -----------------------------------------------
+# The interactive animations embedded in user/classification.rst are generated at build time
+# into the media directory rather than committed to the repository.
+
+def _generate_animations(_app) -> None:
+    """
+    Generate the embedded classification animations into the media directory.
+
+    Args:
+        _app (sphinx.application.Sphinx): Sphinx application (unused).
+    Returns:
+        None
+    """
+    from paulie import (  # pylint: disable=import-outside-toplevel
+        animation_anti_commutation_graph,
+        get_pauli_string as p,
+    )
+    media_dir = os.path.join(os.path.dirname(__file__), "media")
+    os.makedirs(media_dir, exist_ok=True)
+    examples = {
+        "example_c": p(["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"]),
+        "example_d": p(["XY", "XZ"], n=4),
+    }
+    for name, generators in examples.items():
+        anim = animation_anti_commutation_graph(generators, interval=1200)
+        html = anim.to_jshtml(default_mode="loop")
+        with open(os.path.join(media_dir, f"{name}.html"), "w", encoding="utf-8") as file:
+            file.write(html)
+
+
+def setup(app) -> None:
+    """
+    Connect the animation generation to the documentation build.
+
+    Args:
+        app (sphinx.application.Sphinx): Sphinx application.
+    Returns:
+        None
+    """
+    app.connect("builder-inited", _generate_animations)

--- a/docs/source/user/classification.rst
+++ b/docs/source/user/classification.rst
@@ -75,6 +75,15 @@ For any generator set consisting of Pauli strings, the anticommutation graph can
    |                | :math:`\left|L^{\mathcal{B}}\right|=3`   |                                                             |
    +----------------+------------------------------------------+-------------------------------------------------------------+
 
+All four canonical types are starlike graphs. The algorithm essentially proceeds by first creating a "core" of vertices (the central vertex of the star and at most two other vertices), and then appending vertices to legs or splitting legs and connecting them to the center, as required. There are essentially four key steps:
+
+- Step 1: Build the core.
+- Step 2: If the vertex to be added is only connected to a subset of the isolated (only connected to center excluding the vertex to be added) vertices,
+  use contractions until it is only connected to one isolated vertex and exit. Otherwise use contractions to disconnect the isolated vertices from the
+  vertex to be added and go to Step 3.
+- Step 3: Use contractions until the vertex is only connected to vertices on the longest leg of the graph.
+- Step 4: Use contractions until we can attach the vertex to the end of the longest leg or to the center. This step cannot always be achieved
+  using just contractions: we may have to remove a vertex to complete this step. But it is fine since we can add it again afterwards without affecting the algebra.
 
 Classification of A-type canonical graph
 ----------------------------------------
@@ -92,7 +101,47 @@ outputs
 
     algebra = 4*so(5)
 
-.. Here we should add some definitions like lit, dependent etc.
+We can also animate the transformation to a canonical graph. The following colour convention
+indicates the role of each vertex at every step of the construction.
+
+.. raw:: html
+
+   <table class="docutils align-default color-legend">
+     <thead>
+       <tr><th>Node</th><th>Colour</th></tr>
+     </thead>
+     <tbody>
+       <tr><td>Vertex being added (lighting)</td><td><span class="swatch" style="background:#e6194b;"></span></td></tr>
+       <tr><td>Vertex being contracted</td><td><span class="swatch" style="background:#f58231;"></span></td></tr>
+       <tr><td>Attachment target</td><td><span class="swatch" style="background:#3cb44b;"></span></td></tr>
+       <tr><td>Dependent vertex</td><td><span class="swatch" style="background:#9a6324;"></span></td></tr>
+       <tr><td>Vertex being removed</td><td><span class="swatch" style="background:#000000;"></span></td></tr>
+       <tr><td>Vertex being replaced</td><td><span class="swatch" style="background:#911eb4;"></span></td></tr>
+       <tr><td>Lit vertex in a leg of length one</td><td><span class="swatch" style="background:#4363d8;"></span></td></tr>
+       <tr><td>Unlit vertex in a leg of length one</td><td><span class="swatch" style="background:#f032e6;"></span></td></tr>
+       <tr><td>Lit vertex</td><td><span class="swatch" style="background:#42d4f4;"></span></td></tr>
+       <tr><td>Unlit vertex</td><td><span class="swatch" style="background:#d3d3d3;"></span></td></tr>
+     </tbody>
+   </table>
+
+.. raw:: html
+   :file: ../media/example_c.html
+
+This is what happens:
+
+1. :math:`IYZI` is added.
+2. :math:`IIXX` is added as one leg.
+3. :math:`IIYZ` is added as the second leg. Now the core is complete.
+4. :math:`IXXI` is added. It is connected to :math:`IIYZ`.
+5. :math:`XXII` is added. It is connected to :math:`IYZI`.
+6. :math:`YZII` is added. It is connected to :math:`IYZI` and :math:`IXXI`. We are now in Step 4. But the configuration of attached vertices is
+   such that we must remove :math:`IXXI` so that it is valid for us to attach :math:`YZII` to :math:`IYZI`.
+7. Now we must add :math:`IXXI` again. It is connected to :math:`YZII` and :math:`IIYZ`. We are now in Step 2. In this case, we pick
+   two isolated vertices :math:`P` and :math:`Q` such that :math:`P` is connected to the vertex to be added and :math:`Q` is not.
+   Then for every remaining vertex :math:`W` which is connected to the vertex to be added, we perform :math:`W\mapsto PQW` and now :math:`PQW`
+   commutes with the vertex to be added, so it is no longer connected. It is guaranteed that such a transformation is always possible by
+   Theorem 4 of :cite:t:`Aguilar_2024`. In our case, we can pick :math:`P=YZII` and :math:`Q=XXII`, which means we have :math:`IIYZ\mapsto ZYYZ`
+   and then we can connect :math:`IXXI` to :math:`YZII`.
 
 According to the table, the resultant graph corresponds to :math:`\mathfrak{so}(5)\oplus \mathfrak{so}(5)\oplus \mathfrak{so}(5)\oplus \mathfrak{so}(5)`. But it is worth noting that it also corresponds to :math:`\mathfrak{sp}(2)\oplus \mathfrak{sp}(2)\oplus \mathfrak{sp}(2)\oplus \mathfrak{sp}(2)`. This shows that there is an exceptional isomorphism between :math:`\mathfrak{so}(5)` and :math:`\mathfrak{sp}(2)`.
 
@@ -112,6 +161,31 @@ outputs
 .. code-block:: bash
 
     algebra = sp(4)
+
+We can also animate the transformation to a star graph, using the same colour convention as above:
+
+.. raw:: html
+   :file: ../media/example_d.html
+
+This is what happens:
+
+1. :math:`IXZI` is added.
+2. :math:`IIXZ` is added as one leg.
+3. :math:`IIXY` is added. It is connected to :math:`IXZI` and :math:`IIXZ`, so we contract with :math:`IXZI` to get :math:`[IXZI, IIXY]\propto IXYY`.
+   We add it as the second leg. Now the core is complete.
+4. :math:`IXYI` is added. It is connected to :math:`IXZI` and :math:`IIXZ`. We are now in Step 2. We pick :math:`P=IIXZ` and :math:`Q=IXYY` and we get
+   :math:`IXZI\mapsto IIIX`. Then we can attach :math:`IXYI` to :math:`IIXZ`.
+5. :math:`XZII` is added. It is connected to :math:`IXYY` and :math:`IXYI`. We are now in Step 2. We can contract with :math:`IXYY` and :math:`IIIX`
+   in that order to get :math:`[IIIX,[IXYY,XZII]]\propto XYYZ`. Now it is connected to :math:`IIIX`, :math:`IIXZ`, and :math:`IXYI`. Now we are in
+   Step 4 of the algorithm. We can contract with :math:`IXYI` to get :math:`[IXYI,XYYZ]\propto XZIZ`. Now it is no longer connected to :math:`IIXZ`.
+   Next we contract with :math:`IIIX` to get :math:`[IIIX,XZIZ]\propto XZIY`. Now :math:`XZIY` is connected to all vertices. Then we contract with
+   :math:`IXYY` to get :math:`[IXYY,XZIY]\propto XYYI`. Now it is connected to all except :math:`IIIX`. Then we contract with :math:`IIXZ` to get
+   :math:`[IIXZ,XYYI]\propto XYZZ`. Now it is connected to all except :math:`IXYI`. Finally, we contract with :math:`IIIX` to get :math:`[IIIX,XYZZ]\propto XYZY`.
+   Now it is attached to only :math:`IIIX`. We can consider :math:`IIIX` as the center.
+6. :math:`XYII` is added. It is connected to :math:`IXYY` and :math:`IXYI`. We are now in Step 2. We pick :math:`P=IXYY` and :math:`Q=XYZY`
+   and we get :math:`IXYI\mapsto XYZI`. Then we can attach :math:`XYII` to :math:`IXYY`.
+
+According to the table, the resultant graph corresponds to :math:`\mathfrak{sp}(4)`.
 
 The Lie algebra plays a pivotal role in quantum control theory to understand the reachability of states.
 Also measures of operator spread complexity rely on this concept.

--- a/src/paulie/__init__.py
+++ b/src/paulie/__init__.py
@@ -33,12 +33,14 @@ from .application.matrix_decomposition import (
     matrix_decomposition,
     matrix_decomposition_diagonal
 )
+from .application.animation import animation_anti_commutation_graph
 
 # Classification
 from .classifier.classification import (
     Morph,
     Classification
 )
+from .classifier.recording_canonicalizer import RecordingCanonicalizer
 
 # Common
 from .common.pauli_string_bitarray import PauliString
@@ -84,10 +86,12 @@ __all__ = [
     "get_pauli_weights",
     "matrix_decomposition",
     "matrix_decomposition_diagonal",
+    "animation_anti_commutation_graph",
 
     # Classification
     "Morph",
     "Classification",
+    "RecordingCanonicalizer",
 
     # Common
     "PauliString",

--- a/src/paulie/application/animation.py
+++ b/src/paulie/application/animation.py
@@ -1,0 +1,63 @@
+"""
+    Module for animating the transformation of the anticommutation graph into a canonical form.
+"""
+import networkx as nx
+from matplotlib.animation import Animation
+from paulie.helpers._recording import RecordGraph
+from paulie.helpers.drawing import _animation_graph
+from paulie.classifier.recording_canonicalizer import RecordingCanonicalizer
+from paulie.common.pauli_string_collection import PauliStringCollection
+
+
+def _build_record(generators: PauliStringCollection) -> RecordGraph:
+    """
+    Record the canonicalization of a generating set.
+
+    The anticommutation graph is split into its connected components and each component is
+    canonicalized in turn, recording every transformation step into a single recording. This
+    mirrors the component iteration of :func:`PauliStringCollection.classify`.
+
+    Args:
+        generators (PauliStringCollection): Collection of Pauli strings.
+    Returns:
+        RecordGraph: Recording of the canonical graph construction.
+    """
+    record = RecordGraph()
+    verts, edges, _ = generators.get_graph()
+    graph: nx.Graph[str] = nx.Graph()
+    graph.add_nodes_from(verts)
+    graph.add_edges_from(edges)
+    for component in nx.connected_components(graph):
+        vertex_stack = [generators.create_instance(pauli_str=s)
+            for s in nx.dfs_preorder_nodes(graph.subgraph(component))]
+        vertex_stack.reverse()
+        RecordingCanonicalizer(record).build_canonical_graph(vertex_stack)
+    return record
+
+
+def animation_anti_commutation_graph(
+    generators: PauliStringCollection,
+    storage: dict[str, str] | None = None,
+    interval: int = 1000,
+    show: bool = False,
+) -> Animation:
+    """
+    Animate the transformation of the anticommutation graph into a canonical form.
+
+    Args:
+        generators (PauliStringCollection): Collection of Pauli strings.
+        storage (dict[str, str], optional): Output location and format. Expected keys
+            ``filename`` and ``writer``. Defaults to None, in which case the animation is not
+            saved.
+        interval (int, optional): Interval between frames in milliseconds.
+        show (bool, optional): Whether to display the animation window.
+    Returns:
+        matplotlib.animation.Animation
+    """
+    record = _build_record(generators)
+    return _animation_graph(
+        record,
+        interval=interval,
+        storage=storage,
+        show=show,
+    )

--- a/src/paulie/classifier/canonicalizer.py
+++ b/src/paulie/classifier/canonicalizer.py
@@ -3,12 +3,13 @@ Canonicalizer of generators
 """
 from paulie.common.pauli_string_bitarray import PauliString
 from paulie.classifier.classification import Morph
+from paulie.classifier.observer import CanonicalizerEvent, EventManager
 
 class Canonicalizer:
     """
     Class of canonicalizer of generators
     """
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize a Canonicalizer
         """
@@ -16,6 +17,45 @@ class Canonicalizer:
         self.central_vertex = None
         self.legs = []
         self.vertex_stack = []
+        self.events = EventManager()
+
+    def _notify(self, event: CanonicalizerEvent, **data: object) -> None:
+        """
+        Notify subscribed observers of a transformation event.
+
+        Args:
+            event (CanonicalizerEvent): Type of event emitted.
+            data: Contextual data associated with the event.
+        Returns:
+            None
+        """
+        if self.events.has_subscribers():
+            self.events.notify(event, data)
+
+    def _current_vertices(self) -> list[PauliString]:
+        """
+        Get the vertices of the canonical graph built so far.
+
+        Returns:
+            list[PauliString]: Central vertex followed by the vertices of each leg.
+        """
+        vertices = []
+        if self.central_vertex is not None:
+            vertices.append(self.central_vertex)
+        for leg in self.legs:
+            vertices.extend(leg)
+        return vertices
+
+    def _lit_neighbours(self, v: PauliString) -> list[PauliString]:
+        """
+        Get the vertices of the current graph that are lit by `v`.
+
+        Args:
+            v (PauliString): Pauli string generating the lighting.
+        Returns:
+            list[PauliString]: Vertices that anticommute with `v`.
+        """
+        return [w for w in self._current_vertices() if self._is_lit(v, w)]
 
     def _set_vertex_stack(self, vertex_stack: list[PauliString]) -> None:
         """
@@ -65,6 +105,8 @@ class Canonicalizer:
         Returns:
             PauliString: Append Pauli string after core installation
         """
+        self._notify(CanonicalizerEvent.BUILD_CORE,
+            collection=self._current_vertices(), lighting=v, lits=self._lit_neighbours(v))
         if len(self.legs) == 1:
             if self._is_lit(v, self.legs[0][0]):
                 if not self._is_lit(v, self.central_vertex):
@@ -83,6 +125,9 @@ class Canonicalizer:
             vertex_stack (list[PauliString]): Generator stack
             v (PauliString): Append Pauli string
         """
+        self._notify(CanonicalizerEvent.CONVERT_SINGLE_LIT_STATE,
+            collection=self._current_vertices(), lighting=v, lits=self._lit_neighbours(v),
+            p=self.legs[p_index][0], q=self.legs[q_index][0])
         pq = (self._representative(self.legs[p_index][0]) @
             self._representative(self.legs[q_index][0]))
         if self._is_lit(v, self.central_vertex):
@@ -108,6 +153,8 @@ class Canonicalizer:
         Returns:
             PauliString: Pauli string after transferring
         """
+        self._notify(CanonicalizerEvent.TRANSFER_LIGHTNING,
+            collection=self._current_vertices(), lighting=v, lits=self._lit_neighbours(v))
         # We need to make self.legs[-1][1] lit
         if not self._is_lit(v, self.legs[-1][1]):
             m = None
@@ -166,6 +213,8 @@ class Canonicalizer:
         Returns:
             PauliString: Pauli string after reduce
         """
+        self._notify(CanonicalizerEvent.REDUCE_LIGHTNING,
+            collection=self._current_vertices(), lighting=v, lits=self._lit_neighbours(v))
         if not self._is_lit(v, self.central_vertex):
             if len(self.legs[-2]) == 1 and len(self.legs[-1]) > 4:
                 #self._debug(v)
@@ -286,12 +335,20 @@ class Canonicalizer:
         while vertex_stack:
             confirmed_legs = [leg for leg in self.legs if len(leg) != 1]
             length_1_legs = [leg for leg in self.legs if len(leg) == 1]
-            confirmed_legs.extend(self._dependency_check(length_1_legs))
+            independent_legs = self._dependency_check(length_1_legs)
+            if self.events.has_subscribers():
+                dropped = [leg[0] for leg in length_1_legs if leg not in independent_legs]
+                if dropped:
+                    self._notify(CanonicalizerEvent.REMOVE_DEPENDENT,
+                        collection=self._current_vertices(), removing=dropped)
+            confirmed_legs.extend(independent_legs)
             self.legs = confirmed_legs
             self.legs.sort(key=len)
             v = vertex_stack.pop()
             if self.central_vertex is None:
                 self.central_vertex = v
+                self._notify(CanonicalizerEvent.CENTRAL_VERTEX,
+                    collection=self._current_vertices())
                 continue
             # Build the core
             if len(self.legs) < 2:
@@ -332,6 +389,9 @@ class Canonicalizer:
                         any_lit_leg = True
                         break
             if not any_lit_leg:
+                self._notify(CanonicalizerEvent.LIGHTING,
+                    collection=self._current_vertices(), lighting=v,
+                    lits=self._lit_neighbours(v))
                 self.legs.append([v])
                 continue
 

--- a/src/paulie/classifier/observer.py
+++ b/src/paulie/classifier/observer.py
@@ -1,0 +1,95 @@
+"""
+Observer machinery for recording the canonicalization process.
+"""
+import enum
+
+
+class CanonicalizerEvent(enum.Enum):
+    """
+    Event emitted by the canonicalizer at each step of the transformation.
+
+    The value of each member is the default human-readable title of the event.
+    """
+    ANTICOMMUTATION_GRAPH = "Anticommutation graph"
+    CENTRAL_VERTEX = "Central vertex"
+    LIGHTING = "Adding"
+    BUILD_CORE = "Build core"
+    CONVERT_SINGLE_LIT_STATE = "Single legs in different lit states"
+    TRANSFER_LIGHTNING = "Transfer lightning to long leg"
+    REDUCE_LIGHTNING = "Reduce lightning on long leg"
+    REMOVE_DEPENDENT = "Remove dependent vertices"
+    CANONICAL = "Canonical graph"
+
+
+class CanonicalizerObserver:
+    """
+    Base class for observers of the canonicalization process.
+    """
+    def update(self, event: CanonicalizerEvent, data: dict) -> None:  # pylint: disable=unused-argument
+        """
+        React to an event emitted by the canonicalizer.
+
+        Args:
+            event (CanonicalizerEvent): Type of event emitted.
+            data (dict): Contextual data associated with the event.
+        Returns:
+            None
+        """
+
+
+class EventManager:
+    """
+    Subscription manager relating a canonicalizer to its observers.
+    """
+    def __init__(self) -> None:
+        """
+        Initialize an EventManager with no subscribers.
+
+        Returns:
+            None
+        """
+        self.subscribers: list[CanonicalizerObserver] = []
+
+    def subscribe(self, observer: CanonicalizerObserver) -> None:
+        """
+        Subscribe an observer.
+
+        Args:
+            observer (CanonicalizerObserver): Observer to subscribe.
+        Returns:
+            None
+        """
+        self.subscribers.append(observer)
+
+    def unsubscribe(self, observer: CanonicalizerObserver) -> None:
+        """
+        Unsubscribe an observer.
+
+        Args:
+            observer (CanonicalizerObserver): Observer to unsubscribe.
+        Returns:
+            None
+        """
+        self.subscribers.remove(observer)
+
+    def has_subscribers(self) -> bool:
+        """
+        Check if there are any subscribers.
+
+        Returns:
+            bool: True if at least one observer is subscribed.
+        """
+        return len(self.subscribers) > 0
+
+    def notify(self, event: CanonicalizerEvent, data: dict) -> None:
+        """
+        Notify all subscribers of an event.
+
+        Args:
+            event (CanonicalizerEvent): Type of event emitted.
+            data (dict): Contextual data associated with the event.
+        Returns:
+            None
+        """
+        for observer in self.subscribers:
+            observer.update(event, data)

--- a/src/paulie/classifier/recording_canonicalizer.py
+++ b/src/paulie/classifier/recording_canonicalizer.py
@@ -1,0 +1,103 @@
+"""
+Recording canonicalizer of generators.
+"""
+from paulie.common.pauli_string_bitarray import PauliString
+from paulie.classifier.canonicalizer import Canonicalizer
+from paulie.classifier.classification import Classification, Morph
+from paulie.classifier.observer import CanonicalizerEvent, CanonicalizerObserver
+from paulie.helpers._recording import RecordGraph, recording_graph
+
+
+class _FrameRecorder(CanonicalizerObserver):
+    """
+    Observer that records each canonicalization event as a frame.
+    """
+    def __init__(self, record: RecordGraph) -> None:
+        """
+        Initialize a frame recorder.
+
+        Args:
+            record (RecordGraph): Recording to append frames to.
+        Returns:
+            None
+        """
+        self.record = record
+
+    def update(self, event: CanonicalizerEvent, data: dict) -> None:
+        """
+        Record a canonicalization event as a frame.
+
+        Args:
+            event (CanonicalizerEvent): Type of event emitted.
+            data (dict): Contextual data associated with the event.
+        Returns:
+            None
+        """
+        title = data.get("title")
+        if title is None:
+            lighting = data.get("lighting")
+            title = f"{event.value}: {lighting}" if lighting is not None else event.value
+        recording_graph(self.record, collection=data.get("collection"),
+                        lighting=data.get("lighting"), lits=data.get("lits"),
+                        p=data.get("p"), q=data.get("q"),
+                        removing_vertices=data.get("removing"),
+                        dependent=data.get("dependent"), title=title,
+                        init=bool(data.get("init", False)))
+
+
+class RecordingCanonicalizer(Canonicalizer):
+    """
+    Canonicalizer that records the transformation process into a RecordGraph.
+    """
+    def __init__(self, record: RecordGraph | None = None) -> None:
+        """
+        Initialize a RecordingCanonicalizer.
+
+        Args:
+            record (RecordGraph, optional): Recording to append frames to. Defaults to None, in
+                which case a new recording is created.
+        Returns:
+            None
+        """
+        super().__init__()
+        self.record = record if record is not None else RecordGraph()
+        self.events.subscribe(_FrameRecorder(self.record))
+
+    def get_record(self) -> RecordGraph:
+        """
+        Get the recording of the transformation process.
+
+        Returns:
+            RecordGraph: Recording of the canonical graph construction.
+        """
+        return self.record
+
+    def build_canonical_graph(self, vertex_stack: list[PauliString]) -> Morph:
+        """
+        Build a canonical graph from a stack of connected generators, recording each step.
+
+        Args:
+            vertex_stack (list[PauliString]): Generator stack.
+        Returns:
+            Morph: Canonical graph.
+        """
+        self._notify(CanonicalizerEvent.ANTICOMMUTATION_GRAPH,
+                     collection=list(vertex_stack), init=True)
+        morph = super().build_canonical_graph(vertex_stack)
+        self._notify(CanonicalizerEvent.CANONICAL,
+                     collection=self._current_vertices(), title=self._final_title(morph))
+        return morph
+
+    def _final_title(self, morph: Morph) -> str:
+        """
+        Build the title of the terminal frame including the classified algebra.
+
+        Args:
+            morph (Morph): Canonical graph.
+        Returns:
+            str: Terminal frame title of the form `Canonical graph of type B3: su(1024)`.
+        """
+        classification = Classification()
+        classification.add(morph)
+        return (f"Canonical graph of type {morph.get_type().name}: "
+                f"{classification.get_algebra()}")

--- a/src/paulie/helpers/_recording.py
+++ b/src/paulie/helpers/_recording.py
@@ -1,0 +1,441 @@
+"""
+    Module that contains classes for creating a recording of the anticommutation graph
+    transformation process.
+"""
+import numpy as np
+from paulie.common.get_graph import get_graph
+from paulie.common.pauli_string_bitarray import PauliString
+
+class FrameGraph:
+    """
+    Stores the graph data in a frame.
+    """
+    def __init__(self, vertices:list[str], edges:list[tuple[str,str]],
+                 edge_labels:dict[tuple[str,str],str] = None
+    ) -> None:
+        """
+        Initialize the frame with graph data (vertices, edges, edge labels).
+
+        Args:
+            vertices (list[str]): List of vertices.
+            edges (list[tuple[str,str]]): List of edges.
+            edge_labels (dict[tuple[str,str],str], optional): List of edge labels.
+        Returns:
+            None
+        """
+        self.vertices = vertices
+        self.edges = edges
+        self.edge_labels = edge_labels
+
+    def get_graph(self
+    ) -> tuple[list[str], list[tuple[str, str]], dict[tuple[str, str], str]]:
+        """
+        Get the graph data in the frame.
+
+        Returns:
+            Vertices, edges, and labels of edges.
+        """
+        return self.vertices.copy(), self.edges.copy(), self.edge_labels
+
+class FrameRecord:
+    """
+    A single frame of a recording.
+    """
+    def __init__(self, graph:FrameGraph=None, lighting:PauliString=None,
+                 appending:PauliString=None, contracting:PauliString=None,
+                 lits:list[PauliString]=None, p:PauliString=None,
+                 q:PauliString=None, removing_vertices:list[PauliString]=None,
+                 replacing_vertices:list[PauliString]=None, dependent:PauliString=None,
+                 title:str=None, init:bool=False) -> None:
+        """
+        Initialize the frame with graph data and the current state of the algorithm.
+
+        Args:
+            graph (FrameGraph, optional): Graph data.
+            lighting (PauliString, optional): Vertex to be added which is generating the lighting.
+            appending (PauliString, optional): Vertex to which the new vertex will be attached.
+            contracting (PauliString, optional): Vertex which is being contracted.
+            lits (list[PauliString], optional): List of lit vertices.
+            p (PauliString, optional): Lit vertex in a leg of length 1.
+            q (PauliString, optional): Unlit vertex in a leg of length 1.
+            removing_vertices (list[PauliString], optional): List of vertices to be removed.
+            replacing_vertices (list[PauliString], optional): List of vertices to be replaced.
+            dependent (PauliString, optional): Dependent vertex.
+            title (str, optional): Title of frame.
+            init (bool, optional): Whether this is the initial frame. Defaults to `False`.
+        Returns:
+            None
+        """
+        self.graph = graph
+        self.lighting = str(lighting) if lighting else None
+        self.lits = [str(v) for v in lits] if lits else []
+        self.p = str(p) if p else None
+        self.q = str(q) if q else None
+        self.removing_vertices = [str(v) for v in removing_vertices] if removing_vertices else []
+        self.replacing_vertices = ([str(v) for v in replacing_vertices]
+                                   if replacing_vertices else [])
+        self.dependent = str(dependent) if dependent else None
+        self.title = title
+        self.contracting = str(contracting) if contracting else None
+        self.appending = str(appending) if appending else None
+        self.init = init
+
+    def get_graph(self
+    ) -> tuple[list[str], list[tuple[str, str]], dict[tuple[str, str], str]]:
+        """
+        Get graph data stored in the frame.
+
+        Returns:
+            Vertices, edges, and labels of edges.
+        """
+        if not self.graph:
+            return None
+        return self.graph.get_graph()
+
+    def get_lighting(self) -> str:
+        """
+        Get the vertex to be added.
+
+        Returns:
+            str: The vertex to be added.
+        """
+        return self.lighting
+
+    def get_title(self) -> str:
+        """
+        Get the title of the frame.
+
+        Returns:
+            str: The title of the frame.
+        """
+        return self.title
+
+    def is_appending(self) -> bool:
+        """
+        Check if the new vertex is not being appended to the graph.
+
+        Returns:
+            bool: True if not appending.
+        """
+        return not self.appending
+
+    def get_is_appending(self, vertex: str) -> bool:
+        """
+        Check if the vertex is being appended to.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is being appended to.
+        """
+        if not self.appending:
+            return False
+        return self.appending == vertex
+
+    def get_is_contracting(self, vertex:str) -> bool:
+        """
+        Check if the vertex is being contracted.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is being contracted.
+        """
+        if not self.contracting:
+            return False
+        return self.contracting == vertex
+
+    def get_is_p(self, vertex:str) -> bool:
+        """
+        Check if vertex is p.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is p.
+        """
+        if not self.p:
+            return False
+        return self.p == vertex
+
+    def get_is_q(self, vertex:str) -> bool:
+        """
+        Check if vertex is q.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is q.
+        """
+        if not self.q:
+            return False
+        return self.q == vertex
+
+    def get_is_dependent(self, vertex:str) -> bool:
+        """
+        Check if vertex is dependent.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is dependent.
+        """
+        if not self.dependent:
+            return False
+        return self.dependent == vertex
+
+    def get_is_lits(self, vertex:str) -> bool:
+        """
+        Check if vertex is lit.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is lit.
+        """
+        return vertex in self.lits
+
+    def is_removing(self) -> bool:
+        """
+        Check if vertices are not being removed.
+
+        Returns:
+            bool: True if vertices are not being removed.
+        """
+        return not self.removing_vertices
+
+    def get_is_removing(self, vertex:str) -> bool:
+        """
+        Check if vertex is being removed.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is being removed.
+        """
+        return vertex in self.removing_vertices
+
+    def get_is_replacing(self, vertex:str) -> bool:
+        """
+        Check if vertex is being replaced.
+
+        Args:
+            vertex (str): Vertex for checking.
+        Returns:
+            bool: True if vertex is being replaced.
+        """
+        return vertex in self.replacing_vertices
+
+    def get_init(self) -> bool:
+        """
+        Check if this is the initial frame.
+
+        Returns:
+            bool: True if this is the initial frame.
+        """
+        return self.init
+
+class RecordGraph:
+    """
+    Recording of the canonical graph transformation process.
+    """
+    def __init__(self) -> None:
+        """
+        Initialize an empty record.
+
+        Returns:
+            None
+        """
+        self.frames: list[FrameRecord] = []
+        self.positions: dict[str, np.ndarray] = {}
+        self.assigned_angles: list[float] = []
+        self.x_position_lighting = 0.0
+
+    def append_frame(self, frame: FrameRecord) -> None:
+        """
+        Append a frame to the record.
+
+        Args:
+            frame (FrameRecord): Frame to be added to the record.
+        Returns:
+            None
+        """
+        self.frames.append(frame)
+
+    def append(self, graph: FrameGraph=None,
+               lighting:PauliString=None, appending:PauliString=None,
+               contracting:PauliString=None, lits:list[PauliString]=None,
+               p:PauliString=None, q:PauliString=None,
+               removing_vertices:list[PauliString]=None, replacing_vertices:list[PauliString]=None,
+               dependent:PauliString=None, title:str=None,
+               init:bool=False) -> None:
+        """
+        Make a frame and append it to the record.
+
+        Args:
+            graph (FrameGraph, optional): Graph data.
+            lighting (PauliString, optional): Vertex to be added which is generating the lighting.
+            appending (PauliString, optional): Vertex to which the new vertex will be attached.
+            contracting (PauliString, optional): Vertex which is being contracted.
+            lits (list[PauliString], optional): List of lit vertices.
+            p (PauliString, optional): Lit vertex in a leg of length 1.
+            q (PauliString, optional): Unlit vertex in a leg of length 1.
+            removing_vertices (list[PauliString], optional): List of vertices to be removed.
+            replacing_vertices (list[PauliString], optional): List of vertices to be replaced.
+            dependent (PauliString, optional): Dependent vertex.
+            title (str, optional): Title of frame.
+            init (bool, optional): Whether this is the initial frame. Defaults to `False`.
+        Returns:
+            None
+        """
+        self.append_frame(FrameRecord(graph, lighting=lighting, appending=appending,
+                                      contracting=contracting, lits=lits, p=p, q=q,
+                                      removing_vertices=removing_vertices,
+                                      replacing_vertices=replacing_vertices,
+                                      dependent=dependent, title=title, init=init)
+                          )
+
+    def get_frame(self, index:int) -> FrameRecord:
+        """
+        Get a frame by its index.
+
+        Args:
+            index (int): Index of frame.
+        Returns:
+            FrameRecord: Frame of record.
+        Raises:
+            ValueError: If the index is greater than the number of frames.
+        """
+        if index > len(self.frames) - 1:
+            raise ValueError("Out of index")
+        return self.frames[index]
+
+    def clear(self) -> None:
+        """
+        Clear the record.
+
+        Returns:
+            None
+        """
+        self.frames = []
+
+    def get_size(self) -> int:
+        """
+        Get the number of frames in the record.
+
+        Returns:
+            int: Number of frames.
+        """
+        return len(self.frames)
+
+    def get_graph(self, index:int
+    ) -> tuple[list[str], list[tuple[str, str]], dict[tuple[str, str], str]]|None:
+        """
+        Get graph data by frame index.
+
+        If the frame at `index` has no graph data, the most recent preceding frame with
+        graph data is returned.
+
+        Args:
+            index (int): Index of frame.
+        Returns:
+            Vertices, edges, and labels of edges.
+        """
+        while index > -1:
+            frame = self.get_frame(index)
+            graph = frame.get_graph()
+            if not graph:
+                index -= 1
+                continue
+            return graph
+        return None
+
+    def get_is_prev(self, index:int) -> bool:
+        """
+        Check if a frame has no graph data.
+
+        Args:
+            index (int): Index of frame.
+        Returns:
+            bool: True if the frame has no graph data.
+        """
+        frame = self.get_frame(index)
+        return frame.get_graph() is None
+
+    def set_positions(self, positions:dict[str,np.ndarray]) -> None:
+        """
+        Set the positions of the vertices.
+
+        Args:
+            positions (dict[str,numpy.ndarray]): Positions of vertices.
+        Returns:
+            None
+        """
+        self.positions = positions
+
+    def get_positions(self) -> dict[str,np.ndarray]:
+        """
+        Get the positions of the vertices.
+
+        Returns:
+            dict[str,numpy.ndarray]: Positions of vertices.
+        """
+        return self.positions
+
+    def set_x_position_lighting(self, x_position_lighting:float) -> None:
+        """
+        Set x position of the vertex to be added.
+
+        Args:
+            x_position_lighting (float): x position of the vertex to be added.
+        Returns:
+            None
+        """
+        self.x_position_lighting = x_position_lighting
+
+    def get_x_position_lighting(self) -> float:
+        """
+        Get x position of the vertex to be added.
+
+        Returns:
+            float: x position of the vertex to be added.
+        """
+        return self.x_position_lighting
+
+def recording_graph(record:RecordGraph, collection:list[PauliString]=None,
+                    lighting:PauliString=None, appending:PauliString=None,
+                    contracting:PauliString=None, lits:list[PauliString]=None,
+                    p:PauliString=None, q:PauliString = None,
+                    removing_vertices:list[PauliString]=None,
+                    replacing_vertices:list[PauliString]=None,
+                    dependent:PauliString=None, title:str=None,
+                    init:bool=False) -> None:
+    """
+    Append a frame with the given data to the record.
+
+    Args:
+        record (RecordGraph): Record of graph building.
+        collection (list[PauliString], optional): List of vertices.
+        lighting (PauliString, optional): Vertex to be added which is generating the lighting.
+        appending (PauliString, optional): Vertex to which the new vertex will be attached.
+        contracting (PauliString, optional): Vertex which is being contracted.
+        lits (list[PauliString], optional): List of lit vertices.
+        p (PauliString, optional): Lit vertex in a leg of length 1.
+        q (PauliString, optional): Unlit vertex in a leg of length 1.
+        removing_vertices (list[PauliString], optional): List of vertices to be removed.
+        replacing_vertices (list[PauliString], optional): List of vertices to be replaced.
+        dependent (PauliString, optional): Dependent vertex.
+        title (str, optional): Title of frame.
+        init (bool, optional): Whether this is the initial frame. Defaults to `False`.
+    Returns:
+        None
+    """
+    graph = None
+    if collection is not None:
+        vertices, edges, edge_labels = get_graph(collection)
+        graph = FrameGraph(vertices, edges, edge_labels)
+    record.append(graph, lighting=lighting, appending=appending,
+                  contracting=contracting, lits=lits, p=p, q=q,
+                  removing_vertices=removing_vertices,
+                  replacing_vertices=replacing_vertices,
+                  dependent=dependent, title=title, init=init)

--- a/src/paulie/helpers/drawing.py
+++ b/src/paulie/helpers/drawing.py
@@ -1,10 +1,252 @@
 """
     Module with graph drawing utilities.
 """
+import math
 import networkx as nx
+import matplotlib.pyplot as plt
+import matplotlib.animation
+import numpy as np
+from paulie.helpers._recording import RecordGraph
 from paulie.common.pauli_string_collection import PauliStringCollection
 from paulie.common.pauli_string_bitarray import PauliString
 from paulie.common.get_graph import get_graph
+
+# Colour of each node role in the animation. The same hex values are used in the colour
+# legend of docs/source/user/classification.rst. The palette is chosen to be distinguishable
+# (Sasha Trubetskoy's qualitative set) so the roles can be told apart at a glance.
+NODE_ROLE_COLORS = {
+    "lighting": "#e6194b",
+    "dependent": "#9a6324",
+    "contracting": "#f58231",
+    "appending": "#3cb44b",
+    "removing": "#000000",
+    "replacing": "#911eb4",
+    "p": "#4363d8",
+    "q": "#f032e6",
+    "lit": "#42d4f4",
+    "unlit": "#d3d3d3",
+}
+
+# Human-readable description of each node role, used in the colour legend.
+NODE_ROLE_LABELS = {
+    "lighting": "Vertex being added (lighting)",
+    "dependent": "Dependent vertex",
+    "contracting": "Vertex being contracted",
+    "appending": "Attachment target",
+    "removing": "Vertex being removed",
+    "replacing": "Vertex being replaced",
+    "p": "Lit vertex in a leg of length one",
+    "q": "Unlit vertex in a leg of length one",
+    "lit": "Lit vertex",
+    "unlit": "Unlit vertex",
+}
+
+# Constant spacing between consecutive vertices on a leg, and the fixed height at which the
+# vertex being added hovers above the centre. Keeping these constant (rather than rescaling to
+# fit the figure) is what stops vertices and edge lengths from jumping between frames.
+_LAYOUT_DIST = 0.6
+_LIGHTING_Y = 1.6
+# Long legs snake into rows of at most _FOLD_LENGTH vertices, _FOLD_DIST apart. The fold is a
+# pure function of the depth on the leg, so it is part of the layout from the first frame and
+# never repositions a vertex when the leg grows.
+_FOLD_LENGTH = 8
+_FOLD_DIST = 0.5
+# Angular slots for legs, in the order they are first assigned: the first two legs form a
+# horizontal backbone through the centre, the rest fan out above and below.
+_LEG_ANGLES = [
+    0.0, math.pi,
+    math.pi / 2, -math.pi / 2,
+    math.pi / 4, -math.pi / 4, 3 * math.pi / 4, -3 * math.pi / 4,
+    math.pi / 6, -math.pi / 6, 5 * math.pi / 6, -5 * math.pi / 6,
+    math.pi / 3, -math.pi / 3, 2 * math.pi / 3, -2 * math.pi / 3,
+]
+
+
+def _reconstruct_legs(edges: list[tuple[str, str]], center: str) -> list[list[str]]:
+    """
+    Reconstruct the legs of a starlike graph from its edge list.
+
+    Each neighbour of the centre starts a leg, which is extended by following the unique chain
+    of edges away from the centre until it ends.
+
+    Args:
+        edges (list[tuple[str, str]]): Edges of the graph.
+        center (str): Central vertex.
+    Returns:
+        list[list[str]]: Legs, each ordered from the centre outward.
+    """
+    legs = []
+    for edge in edges:
+        if center in edge:
+            v = edge[1] if center == edge[0] else edge[0]
+            legs.append([v])
+    for leg in legs:
+        current = leg[0]
+        while True:
+            is_found = False
+            for edge in edges:
+                if current in edge:
+                    v = edge[1] if current == edge[0] else edge[0]
+                    if v not in leg and v != center:
+                        leg.append(v)
+                        current = v
+                        is_found = True
+                        break
+            if not is_found:
+                break
+    return legs
+
+
+def _next_leg_angle(assigned_angles: list[float]) -> float:
+    """
+    Pick the next unused angular slot for a new leg.
+
+    Args:
+        assigned_angles (list[float]): Angles already assigned to legs.
+    Returns:
+        float: Angle for the new leg, in radians.
+    """
+    for angle in _LEG_ANGLES:
+        if all(abs(angle - used) > 1e-6 for used in assigned_angles):
+            return angle
+    # Fall back to the golden angle once the fixed slots are exhausted.
+    return (len(assigned_angles) * 2.399963) % (2 * math.pi)
+
+
+def _leg_offset(depth: int, ray: np.ndarray) -> np.ndarray:
+    """
+    Offset of the vertex at a given depth on a leg, relative to the centre.
+
+    The leg snakes: rows of ``_FOLD_LENGTH`` vertices run along the leg's ray, alternating
+    direction, each row shifted perpendicular to the ray. The offset depends only on the depth,
+    so a vertex keeps its position no matter when the leg grows past a fold.
+
+    Args:
+        depth (int): Index of the vertex on the leg, counted from the centre.
+        ray (numpy.ndarray): Unit direction of the leg.
+    Returns:
+        numpy.ndarray: Offset from the centre position.
+    """
+    row, col = divmod(depth, _FOLD_LENGTH)
+    along = col + 1 if row % 2 == 0 else _FOLD_LENGTH - col
+    perp = np.array([-ray[1], ray[0]])
+    return ray * along * _LAYOUT_DIST - perp * row * _FOLD_DIST
+
+
+def _recover_leg_ray(leg: list[str], positions: dict[str, np.ndarray],
+    center_pos: np.ndarray) -> np.ndarray | None:
+    """
+    Recover the outward unit direction of a leg from any already-placed vertex on it.
+
+    Inverts :func:`_leg_offset` for the vertex's depth: the offset is linear in the ray, so the
+    ray is the solution of a 2x2 system. A relabelled or newly added vertex on an existing leg
+    is then positioned consistently from any surviving vertex, so placed vertices never move.
+
+    Args:
+        leg (list[str]): Leg vertices, ordered from the centre outward.
+        positions (dict[str, numpy.ndarray]): Known vertex positions.
+        center_pos (numpy.ndarray): Position of the central vertex.
+    Returns:
+        numpy.ndarray|None: Unit direction of the leg, or None if no vertex is placed yet.
+    """
+    for depth, v in enumerate(leg):
+        if v in positions:
+            row, col = divmod(depth, _FOLD_LENGTH)
+            along = col + 1 if row % 2 == 0 else _FOLD_LENGTH - col
+            # offset = along * d * ray - row * f * perp(ray) is linear in the ray:
+            # offset = (along * d * I - row * f * J) @ ray with J the 90-degree rotation.
+            a = along * _LAYOUT_DIST
+            b = row * _FOLD_DIST
+            matrix = np.array([[a, b], [-b, a]])
+            ray = np.linalg.solve(matrix, positions[v] - center_pos)
+            norm = float(np.linalg.norm(ray))
+            if norm > 1e-9:
+                return ray / norm
+    return None
+
+
+def _remember_angle(angle: float, assigned_angles: list[float]) -> None:
+    """
+    Record an angle as used, unless an equivalent angle is already recorded.
+
+    Args:
+        angle (float): Angle in radians.
+        assigned_angles (list[float]): Angles already assigned to legs, mutated in place.
+    Returns:
+        None
+    """
+    for used in assigned_angles:
+        if abs((angle - used + math.pi) % (2 * math.pi) - math.pi) < 1e-6:
+            return
+    assigned_angles.append(angle)
+
+
+def _stable_positions(positions: dict[str, np.ndarray], assigned_angles: list[float],
+    edges: list[tuple[str, str]], center: str) -> float:
+    """
+    Lay out the canonical graph, moving a vertex only when its place in the graph has changed.
+
+    The centre sits at the origin, each leg lies along a fixed ray, and a vertex sits at the
+    offset :func:`_leg_offset` of its depth on the leg, snaking into rows once the leg grows
+    long. A leg keeps the ray recovered from its already-placed vertices, so growing a leg or
+    relabelling a vertex in place never moves the others; only when the algorithm restructures
+    a leg (splitting it or moving vertices between legs) are the affected vertices repositioned
+    onto their new slots. Spacing is constant throughout, so distances never jump.
+
+    Args:
+        positions (dict[str, numpy.ndarray]): Persistent vertex positions, mutated in place.
+        assigned_angles (list[float]): Angles already assigned to legs, mutated in place.
+        edges (list[tuple[str, str]]): Edges of the current canonical graph.
+        center (str): Central vertex.
+    Returns:
+        float: x coordinate of the central vertex.
+    """
+    if center not in positions:
+        positions[center] = np.array([0.0, 0.0])
+    center_pos = positions[center]
+
+    claimed: list[np.ndarray] = []
+    for leg in _reconstruct_legs(edges, center):
+        ray = _recover_leg_ray(leg, positions, center_pos)
+        # Two legs cannot share a ray: a split leg whose vertices still sit on the old ray
+        # is given a fresh slot instead of overlapping the leg that kept it.
+        if ray is not None and any(float(np.dot(ray, c)) > 0.999 for c in claimed):
+            ray = None
+        if ray is None:
+            angle = _next_leg_angle(assigned_angles)
+            ray = np.array([math.cos(angle), math.sin(angle)])
+        _remember_angle(math.atan2(ray[1], ray[0]), assigned_angles)
+        claimed.append(ray)
+        for depth, v in enumerate(leg):
+            expected = center_pos + _leg_offset(depth, ray)
+            if v not in positions or not np.allclose(positions[v], expected, atol=1e-9):
+                positions[v] = expected
+    return float(center_pos[0])
+
+
+def _view_limits(positions: dict[str, np.ndarray]
+) -> tuple[tuple[float, float], tuple[float, float]] | None:
+    """
+    Compute fixed axis limits covering every vertex position, with a margin.
+
+    Fixing the viewport across frames keeps the graph stationary so it grows in place instead
+    of the view jumping or zooming between frames.
+
+    Args:
+        positions (dict[str, numpy.ndarray]): All vertex positions in the animation.
+    Returns:
+        tuple|None: ``((xmin, xmax), (ymin, ymax))`` limits, or None if there are no positions.
+    """
+    if not positions:
+        return None
+    xs = [pos[0] for pos in positions.values()]
+    ys = [pos[1] for pos in positions.values()]
+    xmin, xmax = min(xs), max(xs)
+    ymin, ymax = min(ys), max(ys + [_LIGHTING_Y + _LAYOUT_DIST])
+    margin_x = 0.15 * (xmax - xmin) + 0.2
+    margin_y = 0.15 * (ymax - ymin) + 0.2
+    return (xmin - margin_x, xmax + margin_x), (ymin - margin_y, ymax + margin_y)
+
 
 def plot_graph(vertices:list[str],
                edges:list[tuple[str,str]],
@@ -46,3 +288,186 @@ def plot_graph_by_nodes(nodes:PauliStringCollection,
         commutators = []
     vertices, edges, edge_labels = get_graph(nodes, commutators)
     return plot_graph(vertices, edges, edge_labels)
+
+def _animation_graph(
+    record: RecordGraph,
+    interval: int = 1000,
+    repeat: bool = False,
+    storage: dict | None = None,
+    show: bool = True,
+) -> matplotlib.animation.Animation:
+    """
+    Animate the canonical graph construction from a recording.
+
+    Vertex positions are cached in the recording and assigned incrementally, so a vertex keeps
+    its position for the whole animation and the graph grows without jumping between frames.
+
+    Args:
+        record (RecordGraph): A recording of the canonical graph construction.
+        interval (int, optional): Interval between frames in milliseconds.
+        repeat (bool, optional): Whether to loop the animation.
+        storage (dict, optional): Output location and format. Expected keys:
+            - "filename": path to the output file
+            - "writer": matplotlib writer name or writer instance
+        show (bool, optional): Whether to display the animation window.
+
+    Returns:
+        matplotlib.animation.Animation
+    """
+    graph = nx.Graph()
+    fig, ax = plt.subplots(figsize=(6, 4))
+
+    # Pre-compute every frame's positions so the viewport can be fixed: the graph then grows
+    # in place instead of the view jumping or zooming between frames. The layout state is
+    # reset afterwards so playback rebuilds the identical position sequence from scratch.
+    all_positions: dict[str, np.ndarray] = {}
+    for num in range(record.get_size()):
+        if record.get_frame(num).get_init():
+            continue
+        frame_vertices, frame_edges, _ = record.get_graph(num)
+        if frame_vertices:
+            _stable_positions(record.get_positions(), record.assigned_angles,
+                              list(frame_edges), frame_vertices[0])
+            all_positions.update(record.get_positions())
+    view_limits = _view_limits(all_positions)
+    record.set_positions({})
+    record.assigned_angles.clear()
+
+    def clear() -> None:
+        ax.clear()
+        graph.remove_nodes_from(list(graph.nodes))
+
+    def update(num: int):
+        clear()
+        frame = record.get_frame(num)
+        ax.set_title(f"{frame.get_title()}")
+
+        vertices, base_edges, edge_labels = record.get_graph(num)
+        vertices = list(vertices)
+        base_edges = list(base_edges)
+
+        center = vertices[0] if vertices else None
+        # Labels become an unreadable smear on long Pauli strings or crowded graphs; the node
+        # colours and the frame title still tell the story, so drop the labels there.
+        with_labels = True
+        if (center is not None and len(center) > 10) or len(vertices) > 12:
+            edge_labels = None
+            with_labels = False
+
+        # The initial frame is the raw input graph, drawn with a spring layout. Every later
+        # frame uses the persistent, incremental layout so placed vertices never move.
+        if frame.get_init() or center is None:
+            graph.add_nodes_from(vertices)
+            graph.add_edges_from(base_edges)
+            positions = nx.spring_layout(graph, seed=7)
+            center_x = 0.0
+        else:
+            center_x = _stable_positions(record.get_positions(), record.assigned_angles,
+                                         base_edges, center)
+            positions = dict(record.get_positions())
+            graph.add_nodes_from(vertices)
+            graph.add_edges_from(base_edges)
+
+        # Overlay the vertex being added at a fixed position above the centre, with edges to
+        # the vertices it lights up.
+        lighting = frame.get_lighting()
+        if lighting:
+            if len(lighting) > 10:
+                edge_labels = None
+                with_labels = False
+            graph.add_node(lighting)
+            positions[lighting] = np.array([center_x, _LIGHTING_Y])
+            for v in vertices:
+                if frame.get_is_lits(v):
+                    graph.add_edge(lighting, v)
+            if frame.get_is_dependent(lighting):
+                dependent = lighting
+                lighting = f"dependent {lighting}"
+                graph.add_node(lighting)
+                positions[lighting] = np.array([center_x, _LIGHTING_Y + _LAYOUT_DIST])
+                graph.add_edge(dependent, lighting)
+
+        if frame.is_appending() and frame.is_removing():
+            graph.remove_nodes_from([v for v in vertices if frame.get_is_removing(v)])
+
+        # Any node still without a position (a relabelled straggler) is relaxed in while every
+        # already-placed vertex stays fixed.
+        missing = [n for n in graph.nodes if n not in positions]
+        if missing:
+            fixed = [n for n in positions if n in graph]
+            positions = nx.spring_layout(graph, pos=positions, fixed=fixed or None, seed=7)
+
+        color_map = []
+        for node in graph:
+            if lighting == node:
+                if frame.get_is_dependent(node):
+                    color_map.append(NODE_ROLE_COLORS["dependent"])
+                else:
+                    color_map.append(NODE_ROLE_COLORS["lighting"])
+            elif not frame.get_is_lits(node):
+                if frame.get_is_q(node):
+                    color_map.append(NODE_ROLE_COLORS["q"])
+                elif frame.get_is_removing(node):
+                    color_map.append(NODE_ROLE_COLORS["removing"])
+                else:
+                    color_map.append(NODE_ROLE_COLORS["unlit"])
+            else:
+                if frame.get_is_appending(node):
+                    color_map.append(NODE_ROLE_COLORS["appending"])
+                elif frame.get_is_contracting(node):
+                    color_map.append(NODE_ROLE_COLORS["contracting"])
+                elif frame.get_is_p(node):
+                    color_map.append(NODE_ROLE_COLORS["p"])
+                elif frame.get_is_replacing(node):
+                    color_map.append(NODE_ROLE_COLORS["replacing"])
+                else:
+                    color_map.append(NODE_ROLE_COLORS["lit"])
+
+        ax.axis("off")
+
+        if edge_labels is not None:
+            nx.draw_networkx_edge_labels(
+                graph,
+                pos=positions,
+                edge_labels=edge_labels,
+                font_color="red",
+                hide_ticks=True,
+                node_size=60,
+                font_size=6,
+                ax=ax,
+            )
+
+        artists = nx.draw_networkx(
+            graph,
+            pos=positions,
+            node_color=color_map,
+            hide_ticks=True,
+            node_size=60,
+            font_size=6,
+            with_labels=with_labels,
+            edge_color="#aaaaaa",
+            ax=ax,
+        )
+
+        # Fix the viewport on the construction frames so the graph stays put as it grows.
+        if not frame.get_init() and view_limits is not None:
+            ax.set_xlim(view_limits[0])
+            ax.set_ylim(view_limits[1])
+
+        return artists
+
+    ani = matplotlib.animation.FuncAnimation(
+        fig,
+        update,
+        frames=record.get_size(),
+        interval=interval,
+        repeat=repeat,
+    )
+
+    if storage is not None:
+        ani.save(filename=storage["filename"], writer=storage["writer"])
+
+    if show:
+        plt.show()
+
+    return ani

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""
+Shared test configuration.
+"""
+import matplotlib
+
+# Use a non-interactive backend so the animation tests run headless.
+matplotlib.use("Agg")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -51,10 +51,12 @@ public_symbols = [
     "get_pauli_weights",
     "matrix_decomposition",
     "matrix_decomposition_diagonal",
+    "animation_anti_commutation_graph",
 
     # Classification
     "Morph",
     "Classification",
+    "RecordingCanonicalizer",
 
     # Common
     "PauliString",

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,0 +1,225 @@
+"""
+Test recording and animation of the canonicalization process.
+"""
+import networkx as nx
+import numpy as np
+import pytest
+
+from paulie import G_LIE, RecordingCanonicalizer, get_pauli_string as p
+from paulie.application.animation import _build_record, animation_anti_commutation_graph
+from paulie.classifier.classification import Classification
+from paulie.helpers._recording import RecordGraph
+from paulie.helpers.drawing import NODE_ROLE_COLORS, NODE_ROLE_LABELS, _stable_positions
+
+A_TYPE = ["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"]
+B_TYPE = ["XY", "XZ"]
+
+# (generators, qubit number, expected algebra)
+SMALL_CASES = [
+    (["XY"], 3, "so(3)"),
+    (A_TYPE, None, "4*so(5)"),
+    (B_TYPE, 4, "sp(4)"),
+]
+
+
+def _collection(generators: list[str], n: int | None):
+    """
+    Build a collection of generators for a test case.
+
+    Args:
+        generators (list[str]): Pauli strings.
+        n (int): Number of qubits, or None.
+    Returns:
+        PauliStringCollection: Collection of generators.
+    """
+    return p(generators) if n is None else p(generators, n=n)
+
+
+@pytest.mark.parametrize("generators, n, expected", SMALL_CASES)
+def test_recording_matches_plain_classification(generators, n, expected) -> None:
+    """
+    Recording the construction does not change the classified algebra.
+    """
+    collection = _collection(generators, n)
+    assert collection.get_algebra() == expected
+
+    classification = Classification()
+    record = RecordGraph()
+    verts, edges, _ = collection.get_graph()
+    graph = nx.Graph()
+    graph.add_nodes_from(verts)
+    graph.add_edges_from(edges)
+    for component in nx.connected_components(graph):
+        vertex_stack = [collection.create_instance(pauli_str=s)
+            for s in nx.dfs_preorder_nodes(graph.subgraph(component))]
+        vertex_stack.reverse()
+        classification.add(RecordingCanonicalizer(record).build_canonical_graph(vertex_stack))
+    assert str(classification.get_algebra()) == expected
+
+
+@pytest.mark.parametrize("generators, n, _expected", SMALL_CASES)
+def test_record_is_non_empty(generators, n, _expected) -> None:
+    """
+    A recording has at least an initial and a terminal frame.
+    """
+    record = _build_record(_collection(generators, n))
+    assert record.get_size() >= 2
+
+
+@pytest.mark.parametrize("generators, n, _expected", SMALL_CASES)
+def test_initial_frame_is_input_graph(generators, n, _expected) -> None:
+    """
+    The initial frame is flagged as the input graph and is well-formed.
+    """
+    record = _build_record(_collection(generators, n))
+    frame = record.get_frame(0)
+    assert frame.get_init() is True
+    vertices, edges, _ = frame.get_graph()
+    assert len(set(vertices)) == len(vertices)
+    assert len(vertices) >= 1
+    for u, v in edges:
+        assert u in vertices and v in vertices
+
+
+@pytest.mark.parametrize("generators, n, expected", SMALL_CASES)
+def test_terminal_frame_is_canonical(generators, n, expected) -> None:
+    """
+    The terminal frame is a canonical graph whose title carries the algebra name.
+    """
+    record = _build_record(_collection(generators, n))
+    last = record.get_frame(record.get_size() - 1)
+    assert last.get_title().startswith("Canonical graph")
+    assert expected in last.get_title()
+    assert last.get_lighting() is None
+
+
+@pytest.mark.parametrize("generators, n, _expected", SMALL_CASES)
+def test_every_frame_is_well_formed(generators, n, _expected) -> None:
+    """
+    Every frame resolves to a well-formed graph with unique vertices and valid edges.
+    """
+    record = _build_record(_collection(generators, n))
+    for index in range(record.get_size()):
+        vertices, edges, _ = record.get_graph(index)
+        assert len(set(vertices)) == len(vertices)
+        for u, v in edges:
+            assert u in vertices and v in vertices
+
+
+@pytest.mark.parametrize("generators, n, _expected", SMALL_CASES)
+def test_lit_vertices_are_distinct_from_lighting(generators, n, _expected) -> None:
+    """
+    The vertex being added is never marked as one of its own lit neighbours.
+    """
+    record = _build_record(_collection(generators, n))
+    for index in range(record.get_size()):
+        frame = record.get_frame(index)
+        lighting = frame.get_lighting()
+        if lighting is not None:
+            assert not frame.get_is_lits(lighting)
+
+
+@pytest.mark.parametrize("generators, n, _expected", SMALL_CASES)
+def test_recording_canonicalizer_is_drop_in(generators, n, _expected) -> None:
+    """
+    RecordingCanonicalizer returns a canonical Morph just like the base Canonicalizer.
+    """
+    collection = _collection(generators, n)
+    verts, edges, _ = collection.get_graph()
+    graph = nx.Graph()
+    graph.add_nodes_from(verts)
+    graph.add_edges_from(edges)
+    for component in nx.connected_components(graph):
+        vertex_stack = [collection.create_instance(pauli_str=s)
+            for s in nx.dfs_preorder_nodes(graph.subgraph(component))]
+        vertex_stack.reverse()
+        morph = RecordingCanonicalizer().build_canonical_graph(vertex_stack)
+        assert morph.get_type().name in {"A", "B1", "B2", "B3", "NONE"}
+
+
+def test_layout_is_stable_when_graph_grows() -> None:
+    """
+    Placed vertices keep their position as the graph grows, so the animation does not jump.
+    """
+    positions: dict[str, np.ndarray] = {}
+    angles: list[float] = []
+    _stable_positions(positions, angles, [("C", "A"), ("C", "B")], "C")
+    snapshot = {v: pos.copy() for v, pos in positions.items()}
+    # Extend a leg and add a new leg.
+    _stable_positions(positions, angles, [("C", "A"), ("A", "D"), ("C", "B"), ("C", "E")], "C")
+    for v, pos in snapshot.items():
+        assert np.allclose(positions[v], pos)
+    assert "D" in positions and "E" in positions
+
+
+def test_layout_is_stable_under_relabel() -> None:
+    """
+    A relabelled leg vertex inherits the position of the slot it occupies.
+    """
+    positions: dict[str, np.ndarray] = {}
+    angles: list[float] = []
+    _stable_positions(positions, angles, [("C", "A"), ("A", "B")], "C")
+    pos_b = positions["B"].copy()
+    # `B` is relabelled to `B2` at the same depth on the same leg.
+    _stable_positions(positions, angles, [("C", "A"), ("A", "B2")], "C")
+    assert np.allclose(positions["B2"], pos_b)
+
+
+def test_layout_is_stable_across_a_fold() -> None:
+    """
+    Growing a leg past the fold length never moves the vertices already placed on it.
+    """
+    positions: dict[str, np.ndarray] = {}
+    angles: list[float] = []
+    chain = [f"V{i}" for i in range(14)]
+    snapshots = {}
+    for length in range(1, len(chain) + 1):
+        edges = [("C", chain[0])] + [(chain[i], chain[i + 1]) for i in range(length - 1)]
+        _stable_positions(positions, angles, edges, "C")
+        for v, pos in snapshots.items():
+            assert np.allclose(positions[v], pos)
+        snapshots = {v: pos.copy() for v, pos in positions.items()}
+    # The leg folds into rows instead of running off along a single ray.
+    xs = [abs(pos[0]) for pos in positions.values()]
+    assert max(xs) <= 8 * 0.6 + 1e-9
+
+
+def test_role_legend_is_consistent() -> None:
+    """
+    Every node role has both a colour and a label, and the colours are hex values.
+    """
+    assert set(NODE_ROLE_LABELS) == set(NODE_ROLE_COLORS)
+    for color in NODE_ROLE_COLORS.values():
+        assert color.startswith("#") and len(color) == 7
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", sorted(G_LIE))
+def test_recording_matches_plain_for_all_two_local_algebras(name) -> None:
+    """
+    Recording never changes the classified algebra, for every two-local algebra.
+    """
+    collection = p(G_LIE[name], n=6)
+    expected = collection.get_algebra()
+    classification = Classification()
+    verts, edges, _ = collection.get_graph()
+    graph = nx.Graph()
+    graph.add_nodes_from(verts)
+    graph.add_edges_from(edges)
+    for component in nx.connected_components(graph):
+        vertex_stack = [collection.create_instance(pauli_str=s)
+            for s in nx.dfs_preorder_nodes(graph.subgraph(component))]
+        vertex_stack.reverse()
+        classification.add(RecordingCanonicalizer().build_canonical_graph(vertex_stack))
+    assert sorted(str(classification.get_algebra()).split("+")) == sorted(expected.split("+"))
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("generators, n", [(A_TYPE, None), (B_TYPE, 4)])
+def test_animation_renders(generators, n) -> None:
+    """
+    The animation renders to an interactive HTML player without error.
+    """
+    anim = animation_anti_commutation_graph(_collection(generators, n))
+    html = anim.to_jshtml()
+    assert isinstance(html, str) and len(html) > 0


### PR DESCRIPTION
  Closes #199. An alternative implementation of the graph-transformation animation (see also #207).

  Reintroduces the animation feature by wrapping the current `Canonicalizer` with an observer
  (as suggested in the issue), so the recorder only watches and never changes the algorithm.

  ## Demo
  
  Smooth on a long leg (algebra `a17`, `n=10`). Positions and distances stay fixed as the graph
  grows; a vertex moves only when the algorithm actually restructures its leg:

<img width="600" height="400" alt="a17_n10" src="https://github.com/user-attachments/assets/48883782-e643-4548-89b5-c2dec36d568b" />
  
  A-type `4*so(5)` and B-type `sp(4)` worked examples:

<img width="600" height="400" alt="example_c" src="https://github.com/user-attachments/assets/ae6c55ca-79df-4f67-aeae-404a29dec95a" />

<img width="600" height="400" alt="example_d" src="https://github.com/user-attachments/assets/6da307f8-7a69-45db-b8ca-7ac80e187b7e" />


  ## What's included
  - **Recording layer** (`helpers/_recording.py`): `RecordGraph` / `FrameRecord` / `FrameGraph` /
    `recording_graph`, capturing every event (lighting, contraction, attach, p/q, removals,
    replacements, dependents, leg manipulation).
  - **Observer** (`classifier/observer.py`): typed `CanonicalizerEvent` enum + `EventManager`.
    The base `Canonicalizer` emits guarded notifications and is a no-op when nothing subscribes,
    so behaviour and all existing tests are unchanged.
  - **`RecordingCanonicalizer`** (`classifier/recording_canonicalizer.py`): drop-in subclass,
    mirrors the existing `TrackedCanonicalizer` idiom; a recorded run classifies identically to
    a plain one.
  - **Renderer** (`helpers/drawing.py`): per-role colours, an interactive `to_jshtml` player
    (play / pause / step / slider), and a stable incremental layout.
  - **Docs**: restored A-type and B-type walkthroughs in `classification.rst` with embedded
    players and a swatch colour legend. Animations are generated at build time by `conf.py`, so
    no media is committed. `docs/generate_animations.py` regenerates them locally.

  ## Notes on the review feedback raised so far
  - **Smooth, no-jump animation**: the layout is persistent and incremental. A vertex keeps its
    position, spacing is constant, long legs fold into rows, and the viewport is frozen. On
    `a17, n=10` (51 frames) only 8 frames have any motion, each a genuine restructure, ending in
    a clean star.
  - **Algebra in the terminal title**: e.g. `Canonical graph of type B3: su(1024)`.
  - **Distinguishable swatch legend**: reuses the existing `.color-legend` / `.swatch` CSS.
  - **Interactive control bar**: `to_jshtml(default_mode="loop")`.
  - **Commented geometry**: the new layout is documented block by block.
  - **Rebased on current `main`** (post low-rank-isomorphism); `classification.py` is untouched.
  
  ## Testing
  - New `tests/test_recording.py`: frame invariants, layout stability (growth / relabel / fold),
    and recorded-vs-plain algebra equality across all `G_LIE` two-local algebras.
  - Full suite: 966 passing. `ruff`, `pylint` (10/10), `mypy src/paulie/application`, and
    `sphinx-build -W` all green.