### PR TITLE
feat: get_algebra_basis — compact matrix basis for the classified DLA

### DIFF
--- a/docs/source/user/classification.rst
+++ b/docs/source/user/classification.rst
@@ -113,6 +113,40 @@ outputs
 
     algebra = sp(4)
 
+From an algebra label to a matrix basis
+---------------------------------------
+The label returned by :code:`get_algebra` names the dynamical Lie algebra, but algebraic tasks
+such as Cartan decomposition need it as concrete operators. :code:`get_algebra_basis` returns a
+matrix basis of the algebra in its defining representation, in the compact real form so that every
+generator is anti-Hermitian. Reusing the B-type example above:
+
+.. code-block:: python
+
+    generators = p(["XY", "XZ"], n=4)
+    basis = generators.get_algebra_basis()
+    print(f"sp(4): {basis.shape}")
+
+outputs
+
+.. code-block:: bash
+
+    sp(4): (36, 8, 8)
+
+For a direct sum the summands are embedded into distinct diagonal blocks, so the result is a basis
+of the complete operator rather than a stack of per-summand bases. Reusing the A-type example:
+
+.. code-block:: python
+
+    generators = p(["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"])
+    basis = generators.get_algebra_basis()
+    print(f"4*so(5): {basis.shape}")
+
+outputs
+
+.. code-block:: bash
+
+    4*so(5): (40, 20, 20)
+
 The Lie algebra plays a pivotal role in quantum control theory to understand the reachability of states.
 Also measures of operator spread complexity rely on this concept.
 Furthermore, determining moments of circuits can be significantly simplified when the Lie algebra is known.

--- a/src/paulie/classifier/classification.py
+++ b/src/paulie/classifier/classification.py
@@ -4,7 +4,16 @@
 import enum
 from collections.abc import Generator
 
+import numpy as np
+
 from paulie.common.pauli_string_bitarray import PauliString
+from paulie.common.algebra_basis import (
+    block_diagonal_basis,
+    so_basis,
+    sp_basis,
+    su_basis,
+    u1_basis,
+)
 
 
 class ClassificationException(Exception):
@@ -574,6 +583,46 @@ class Classification:
             elif type_algebra == TypeAlgebra.SO:
                 dim += multiplicity * dim_so(n)
         return dim
+
+    def get_algebra_basis(self) -> np.ndarray:
+        """
+        Get a matrix basis of the dynamical Lie algebra in its defining representation.
+
+        Each summand is built in its compact real form, with anti-Hermitian generators (see
+        :mod:`paulie.common.algebra_basis`), and the summands are embedded block-diagonally into a
+        single basis of the complete operator. Summands are ordered by algebra family and then by
+        size, and within a summand by the constructor ordering, so the basis is stable. The number
+        of generators equals :meth:`get_dla_dim`, and they are mutually orthogonal because distinct
+        summands occupy distinct diagonal blocks.
+
+        Returns:
+            numpy.ndarray:
+            Stack of shape ``(get_dla_dim(), size, size)`` of anti-Hermitian matrices, where
+            ``size`` is the summed dimension of the defining representations of the summands.
+
+        Raises:
+            ClassificationException: If a morph has an unsupported algebra type.
+        """
+        constructors = {
+            TypeAlgebra.SO: so_basis,
+            TypeAlgebra.SU: su_basis,
+            TypeAlgebra.SP: sp_basis,
+        }
+        properties = sorted(
+            (morph.get_algebra_properties() for morph in self.morphs),
+            key=lambda algebra_property: (algebra_property[0].value, algebra_property[2]),
+        )
+        summands: list[np.ndarray] = []
+        for type_algebra, nc, n in properties:
+            multiplicity = nc if nc == 1 else 2**(nc - 1)
+            if type_algebra == TypeAlgebra.U:
+                summand = u1_basis()
+            elif type_algebra in constructors:
+                summand = constructors[type_algebra](n)
+            else:
+                raise ClassificationException("Unsupported algebra type")
+            summands.extend([summand] * multiplicity)
+        return block_diagonal_basis(summands)
 
     def _inc_morph_generator(self, ms:int, morphs:list[Morph], morph_generators:list[PauliString],
                              current_morph_generators:list[PauliString]) -> bool:

--- a/src/paulie/common/algebra_basis.py
+++ b/src/paulie/common/algebra_basis.py
@@ -1,0 +1,236 @@
+"""
+Defining-representation matrix bases for the classified Lie algebras.
+
+The bases are the compact real forms used by the recursive Cartan decomposition pipeline of
+Wierichs et al. (arXiv:2503.19014, Eq. (6)-(9)), so every generator is anti-Hermitian and
+``exp`` of any real combination is unitary:
+
+* :math:`\\mathfrak{so}(m)`: real antisymmetric, :math:`x = -x^{T}`.
+* :math:`\\mathfrak{su}(m)`: traceless anti-Hermitian, :math:`x = -x^{\\dagger}`.
+* :math:`\\mathfrak{sp}(m) = \\{x \\in \\mathfrak{su}(2m) : x = -J_m x^{T} J_m^{T}\\}`, the compact
+  symplectic algebra, with :math:`J_m = [[0, \\mathbb{1}_m], [-\\mathbb{1}_m, 0]]`.
+
+Each constructor returns a stack of shape ``(dim, d, d)`` with a fixed, documented ordering so
+that downstream consumers get a stable basis. A direct sum is assembled block-diagonally by
+:func:`block_diagonal_basis` into a single basis of the complete operator. The ordering follows
+the conventions of Wierichs et al. (Tab. II) so the basis feeds directly into the recursive
+Cartan-decomposition (KAK) pipeline that motivates the issue.
+"""
+import numpy as np
+
+
+def _require_positive(n: int, name: str) -> None:
+    """
+    Validate that a size parameter is a positive integer.
+
+    Args:
+        n (int): Size parameter.
+        name (str): Algebra name, used in the error message.
+    Returns:
+        None
+    Raises:
+        ValueError: If ``n`` is not a positive integer.
+    """
+    if not isinstance(n, (int, np.integer)) or n < 1:
+        raise ValueError(f"{name} requires a positive integer size, got {n!r}")
+
+
+def symplectic_form(n: int) -> np.ndarray:
+    """
+    Standard symplectic form :math:`J_n = [[0, I_n], [-I_n, 0]]`.
+
+    Args:
+        n (int): Half the matrix dimension.
+    Returns:
+        numpy.ndarray: The ``2n x 2n`` symplectic form.
+    """
+    _require_positive(n, "symplectic_form")
+    j = np.zeros((2 * n, 2 * n), dtype=np.complex128)
+    j[:n, n:] = np.eye(n)
+    j[n:, :n] = -np.eye(n)
+    return j
+
+
+def so_basis(n: int) -> np.ndarray:
+    """
+    Basis of :math:`\\mathfrak{so}(n)`: real antisymmetric matrices.
+
+    The generators are :math:`E_{ij} - E_{ji}` for :math:`i < j`, ordered by ``i`` then ``j``.
+    Each is real antisymmetric, hence anti-Hermitian, with :math:`\\mathrm{tr}(B^{\\dagger}B) = 2`.
+
+    Args:
+        n (int): Matrix dimension.
+    Returns:
+        numpy.ndarray: Stack of shape ``(n(n-1)/2, n, n)``.
+    Raises:
+        ValueError: If ``n`` is not a positive integer.
+    """
+    _require_positive(n, "so(n)")
+    generators = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            mat = np.zeros((n, n), dtype=np.float64)
+            mat[i, j] = 1.0
+            mat[j, i] = -1.0
+            generators.append(mat)
+    return np.array(generators, dtype=np.float64).reshape((-1, n, n))
+
+
+def su_basis(n: int) -> np.ndarray:
+    """
+    Basis of :math:`\\mathfrak{su}(n)`: traceless anti-Hermitian matrices.
+
+    The generators are the anti-Hermitian generalized Gell-Mann matrices, ordered as
+    antisymmetric :math:`E_{ij} - E_{ji}`, then symmetric :math:`i(E_{ij} + E_{ji})`
+    (both for :math:`i < j`), then the :math:`n - 1` diagonal generators. Every generator is
+    uniformly normalized to :math:`\\mathrm{tr}(B^{\\dagger}B) = 2`.
+
+    Args:
+        n (int): Matrix dimension.
+    Returns:
+        numpy.ndarray: Stack of shape ``(n^2 - 1, n, n)``.
+    Raises:
+        ValueError: If ``n`` is not a positive integer.
+    """
+    _require_positive(n, "su(n)")
+    generators = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            antisymmetric = np.zeros((n, n), dtype=np.complex128)
+            antisymmetric[i, j] = 1.0
+            antisymmetric[j, i] = -1.0
+            generators.append(antisymmetric)
+            symmetric = np.zeros((n, n), dtype=np.complex128)
+            symmetric[i, j] = 1.0j
+            symmetric[j, i] = 1.0j
+            generators.append(symmetric)
+    for level in range(1, n):
+        diagonal = np.zeros((n, n), dtype=np.complex128)
+        scale = np.sqrt(2.0 / (level * (level + 1)))
+        for k in range(level):
+            diagonal[k, k] = 1.0j * scale
+        diagonal[level, level] = -1.0j * scale * level
+        generators.append(diagonal)
+    return np.array(generators, dtype=np.complex128).reshape((-1, n, n))
+
+
+def sp_basis(n: int) -> np.ndarray:
+    """
+    Basis of the compact symplectic algebra :math:`\\mathfrak{sp}(n) = \\mathfrak{usp}(2n)`.
+
+    Generators are the ``2n x 2n`` anti-Hermitian matrices :math:`x = -J_n x^{T} J_n^{T}`,
+    parametrized as :math:`[[A, B], [-\\bar{B}, \\bar{A}]]`
+    with ``A`` anti-Hermitian and ``B`` complex symmetric. The ordering is the ``A`` block
+    (diagonal :math:`iE_{kk}`, then antisymmetric, then symmetric off-diagonal generators of
+    :math:`\\mathfrak{u}(n)`) followed by the ``B`` block (real symmetric, then imaginary
+    symmetric).
+
+    Args:
+        n (int): Rank; the matrices act on :math:`\\mathbb{C}^{2n}`.
+    Returns:
+        numpy.ndarray: Stack of shape ``(n(2n+1), 2n, 2n)``.
+    Raises:
+        ValueError: If ``n`` is not a positive integer.
+    """
+    _require_positive(n, "sp(n)")
+    generators = []
+    for a_block in _anti_hermitian_basis(n):
+        mat = np.zeros((2 * n, 2 * n), dtype=np.complex128)
+        mat[:n, :n] = a_block
+        mat[n:, n:] = np.conjugate(a_block)
+        generators.append(mat)
+    for b_block in _symmetric_basis(n):
+        mat = np.zeros((2 * n, 2 * n), dtype=np.complex128)
+        mat[:n, n:] = b_block
+        mat[n:, :n] = -np.conjugate(b_block)
+        generators.append(mat)
+    return np.array(generators, dtype=np.complex128).reshape((-1, 2 * n, 2 * n))
+
+
+def u1_basis() -> np.ndarray:
+    """
+    Basis of :math:`\\mathfrak{u}(1)`: the single generator :math:`[[i]]`.
+
+    Returns:
+        numpy.ndarray: Stack of shape ``(1, 1, 1)``.
+    """
+    return np.array([[[1.0j]]], dtype=np.complex128)
+
+
+def block_diagonal_basis(summands: list[np.ndarray]) -> np.ndarray:
+    """
+    Assemble a basis of the direct sum from per-summand bases by block-diagonal embedding.
+
+    The direct sum :math:`\\bigoplus_k \\mathfrak{g}_k` is realized in the common space
+    :math:`\\mathbb{C}^{D \\times D}` with :math:`D = \\sum_k d_k`. Summand ``k`` occupies the
+    ``k``-th diagonal block, so the result is a basis of the complete operator (its dimension is
+    :math:`\\sum_k \\dim \\mathfrak{g}_k`) rather than a list of disjoint block bases.
+
+    Args:
+        summands (list[numpy.ndarray]): Per-summand bases, each of shape ``(dim_k, d_k, d_k)``.
+    Returns:
+        numpy.ndarray: Stack of shape ``(sum dim_k, D, D)``.
+    Raises:
+        ValueError: If no summands are given.
+    """
+    if not summands:
+        raise ValueError("a direct sum needs at least one summand")
+    block_dims = [summand.shape[1] for summand in summands]
+    total_dim = sum(summand.shape[0] for summand in summands)
+    size = sum(block_dims)
+    basis = np.zeros((total_dim, size, size), dtype=np.complex128)
+    row = 0
+    offset = 0
+    for summand, dim in zip(summands, block_dims):
+        count = summand.shape[0]
+        basis[row:row + count, offset:offset + dim, offset:offset + dim] = summand
+        row += count
+        offset += dim
+    return basis
+
+
+def _anti_hermitian_basis(n: int) -> list[np.ndarray]:
+    """
+    Basis of :math:`\\mathfrak{u}(n)`: anti-Hermitian matrices (the ``A`` block of sp).
+
+    Args:
+        n (int): Matrix dimension.
+    Returns:
+        list[numpy.ndarray]: The ``n^2`` anti-Hermitian generators.
+    """
+    generators = []
+    for k in range(n):
+        diagonal = np.zeros((n, n), dtype=np.complex128)
+        diagonal[k, k] = 1.0j
+        generators.append(diagonal)
+    for i in range(n):
+        for j in range(i + 1, n):
+            antisymmetric = np.zeros((n, n), dtype=np.complex128)
+            antisymmetric[i, j] = 1.0
+            antisymmetric[j, i] = -1.0
+            generators.append(antisymmetric)
+            symmetric = np.zeros((n, n), dtype=np.complex128)
+            symmetric[i, j] = 1.0j
+            symmetric[j, i] = 1.0j
+            generators.append(symmetric)
+    return generators
+
+
+def _symmetric_basis(n: int) -> list[np.ndarray]:
+    """
+    Basis of complex symmetric matrices (the ``B`` block of sp).
+
+    Args:
+        n (int): Matrix dimension.
+    Returns:
+        list[numpy.ndarray]: The ``n(n+1)`` symmetric generators (real then imaginary).
+    """
+    generators = []
+    for scale in (1.0, 1.0j):
+        for i in range(n):
+            for j in range(i, n):
+                symmetric = np.zeros((n, n), dtype=np.complex128)
+                symmetric[i, j] = scale
+                symmetric[j, i] = scale
+                generators.append(symmetric)
+    return generators

--- a/src/paulie/common/pauli_string_collection.py
+++ b/src/paulie/common/pauli_string_collection.py
@@ -609,6 +609,17 @@ class PauliStringCollection:
         """
         return int(self.get_class().get_dla_dim())
 
+    def get_algebra_basis(self) -> np.ndarray:
+        """
+        Get a matrix basis of the dynamical Lie algebra in its defining representation.
+
+        Returns:
+            numpy.ndarray:
+            Stack of anti-Hermitian matrices forming a basis of the complete operator. See
+            :meth:`paulie.classifier.classification.Classification.get_algebra_basis`.
+        """
+        return self.get_class().get_algebra_basis()
+
     def get_dependents(self) -> PauliStringCollection:
         """
         Get a list of dependent strings in the collection.

--- a/tests/test_algebra_basis.py
+++ b/tests/test_algebra_basis.py
@@ -1,0 +1,281 @@
+"""
+Test matrix bases for the classified Lie algebras.
+"""
+from itertools import combinations
+
+import numpy as np
+import pytest
+
+from paulie import get_pauli_string as p
+from paulie.common.algebra_basis import (
+    block_diagonal_basis,
+    so_basis,
+    sp_basis,
+    su_basis,
+    symplectic_form,
+    u1_basis,
+)
+from paulie.common.two_local_generators import G_LIE
+
+ATOL = 1e-9
+
+
+def _anti_hermitian(basis: np.ndarray) -> bool:
+    """Whether every matrix in the stack is anti-Hermitian."""
+    return all(np.allclose(matrix.conj().T, -matrix, atol=ATOL) for matrix in basis)
+
+
+def _independent(basis: np.ndarray) -> bool:
+    """Whether the matrices are linearly independent."""
+    flat = basis.reshape(basis.shape[0], -1)
+    return np.linalg.matrix_rank(flat, tol=ATOL) == basis.shape[0]
+
+
+def _structure_constants(basis: np.ndarray) -> np.ndarray:
+    """Coefficients of every bracket ``[B_i, B_j]`` in the basis."""
+    flat = basis.reshape(basis.shape[0], -1).T
+    dim = basis.shape[0]
+    constants = np.zeros((dim, dim, dim), dtype=np.complex128)
+    for i in range(dim):
+        for j in range(dim):
+            bracket = (basis[i] @ basis[j] - basis[j] @ basis[i]).reshape(-1)
+            constants[i, j], *_ = np.linalg.lstsq(flat, bracket, rcond=None)
+    return constants
+
+
+def _bracket_closed(basis: np.ndarray) -> bool:
+    """Whether the span is closed under the Lie bracket."""
+    flat = basis.reshape(basis.shape[0], -1).T
+    for i, j in combinations(range(basis.shape[0]), 2):
+        bracket = (basis[i] @ basis[j] - basis[j] @ basis[i]).reshape(-1)
+        coefficients, *_ = np.linalg.lstsq(flat, bracket, rcond=None)
+        if not np.allclose(flat @ coefficients, bracket, atol=ATOL):
+            return False
+    return True
+
+
+def _in_span(matrix: np.ndarray, basis: np.ndarray) -> bool:
+    """Whether a matrix lies in the span of the basis."""
+    flat = basis.reshape(basis.shape[0], -1).T
+    coefficients, *_ = np.linalg.lstsq(flat, matrix.reshape(-1), rcond=None)
+    return np.allclose(flat @ coefficients, matrix.reshape(-1), atol=ATOL)
+
+
+def _spans_equal(first: np.ndarray, second: np.ndarray) -> bool:
+    """Whether two stacks of matrices span the same space."""
+    flat_first = first.reshape(first.shape[0], -1)
+    flat_second = second.reshape(second.shape[0], -1)
+    rank_first = np.linalg.matrix_rank(flat_first, tol=ATOL)
+    rank_second = np.linalg.matrix_rank(flat_second, tol=ATOL)
+    rank_union = np.linalg.matrix_rank(np.vstack([flat_first, flat_second]), tol=ATOL)
+    return rank_first == rank_second == rank_union
+
+
+def _lie_closure(generators: list) -> list:
+    """Brute-force Lie closure as Pauli words, using ``commutes_with`` and ``@``."""
+    closure = list(generators)
+    changed = True
+    while changed:
+        changed = False
+        for left in list(closure):
+            for right in list(closure):
+                if left.commutes_with(right):
+                    continue
+                product = left @ right
+                if all(product != element for element in closure):
+                    closure.append(product)
+                    changed = True
+    return closure
+
+
+def _embedded_dla(collection, n: int) -> np.ndarray:
+    """The embedded DLA as anti-Hermitian ``2^n`` matrices ``i P`` over the Lie closure."""
+    closure = _lie_closure([generator.expand(n) for generator in collection.get()])
+    return np.array([1.0j * word.get_matrix() for word in closure])
+
+
+def _majorana_operators(n: int) -> list:
+    """The ``2n`` Jordan-Wigner Majorana operators on ``n`` qubits as dense matrices."""
+    operators = []
+    for site in range(n):
+        prefix = "Z" * site
+        operators.append(p(prefix + "X" + "I" * (n - site - 1)).get_matrix())
+        operators.append(p(prefix + "Y" + "I" * (n - site - 1)).get_matrix())
+    return operators
+
+
+@pytest.mark.parametrize("n", [2, 3, 4, 5])
+def test_so_basis_is_compact(n) -> None:
+    """The so(n) basis is real antisymmetric, complete, and closed under the bracket.
+    """
+    basis = so_basis(n)
+    assert basis.shape == (n * (n - 1) // 2, n, n)
+    assert all(np.allclose(matrix, -matrix.T) for matrix in basis)
+    assert _anti_hermitian(basis) and _independent(basis) and _bracket_closed(basis)
+    assert all(np.isclose(np.trace(matrix.conj().T @ matrix), 2.0) for matrix in basis)
+
+
+@pytest.mark.parametrize("n", [2, 3, 4])
+def test_su_basis_is_compact(n) -> None:
+    """The su(n) basis is traceless anti-Hermitian and uniformly normalized.
+    """
+    basis = su_basis(n)
+    assert basis.shape == (n * n - 1, n, n)
+    assert _anti_hermitian(basis)
+    assert all(abs(np.trace(matrix)) < ATOL for matrix in basis)
+    assert all(np.isclose(np.trace(matrix.conj().T @ matrix), 2.0) for matrix in basis)
+    assert _independent(basis) and _bracket_closed(basis)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4])
+def test_sp_basis_is_compact(n) -> None:
+    """The sp(n) basis is anti-Hermitian and symplectic, the compact real form.
+    """
+    basis = sp_basis(n)
+    form = symplectic_form(n)
+    assert basis.shape == (n * (2 * n + 1), 2 * n, 2 * n)
+    assert _anti_hermitian(basis)
+    assert all(np.allclose(matrix, -form @ matrix.T @ form.T, atol=ATOL) for matrix in basis)
+    assert _independent(basis) and _bracket_closed(basis)
+
+
+def test_u1_basis() -> None:
+    """The u(1) basis is the single generator [[i]].
+    """
+    basis = u1_basis()
+    assert basis.shape == (1, 1, 1)
+    assert np.allclose(basis[0], [[1.0j]])
+
+
+@pytest.mark.parametrize("constructor", [so_basis, su_basis, sp_basis])
+@pytest.mark.parametrize("size", [0, -1])
+def test_constructors_reject_non_positive_size(constructor, size) -> None:
+    """Every constructor rejects a non-positive size.
+    """
+    with pytest.raises(ValueError):
+        constructor(size)
+
+
+def test_block_diagonal_basis_rejects_empty() -> None:
+    """A direct sum needs at least one summand.
+    """
+    with pytest.raises(ValueError):
+        block_diagonal_basis([])
+
+
+def test_direct_sum_is_a_basis_of_the_complete_operator() -> None:
+    """A direct sum embeds block-diagonally and stays full rank, not identical copies.
+    """
+    basis = block_diagonal_basis([so_basis(3), so_basis(3)])
+    assert basis.shape == (6, 6, 6)
+    assert _anti_hermitian(basis) and _independent(basis) and _bracket_closed(basis)
+    assert np.allclose(basis[:3, 3:, 3:], 0) and np.allclose(basis[3:, :3, :3], 0)
+
+
+# (generators, qubit number, expected algebra label)
+ALGEBRA_CASES = [
+    (["XY"], 3, "so(3)"),
+    (["XX", "XZ"], 3, "so(5)"),
+    (["XX", "YY", "XY"], 3, "so(6)"),
+    (["XY", "XZ"], 4, "sp(4)"),
+    (["XX", "XY", "XZ", "YX"], 3, "su(8)"),
+    (["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"], None, "4*so(5)"),
+    (["XYI", "XZI", "IIZ"], 4, "u(1)+so(6)"),
+]
+
+
+@pytest.mark.parametrize("generators, n, label", ALGEBRA_CASES)
+def test_basis_dimension_matches_dla_dim(generators, n, label) -> None:
+    """The basis is anti-Hermitian with exactly get_dla_dim generators, including mixed sums.
+    """
+    collection = p(generators) if n is None else p(generators, n=n)
+    # get_algebra orders summands non-deterministically, so compare the multiset of terms.
+    assert sorted(collection.get_algebra().split("+")) == sorted(label.split("+"))
+    basis = collection.get_algebra_basis()
+    assert basis.shape[0] == collection.get_dla_dim()
+    assert _anti_hermitian(basis) and _independent(basis)
+
+
+def test_each_summand_block_satisfies_its_own_condition() -> None:
+    """Each diagonal block, not the whole operator, satisfies its summand condition.
+    """
+    basis = p(["IYZI", "IIXX", "IIYZ", "IXXI", "XXII", "YZII"]).get_algebra_basis()
+    assert basis.shape == (40, 20, 20)
+    for element in basis:
+        for row in range(0, 20, 5):
+            for column in range(0, 20, 5):
+                block = element[row:row + 5, column:column + 5]
+                if row == column:
+                    assert np.allclose(block, -block.T)
+                else:
+                    assert np.allclose(block, 0)
+
+
+def test_full_su_reachability_element_wise() -> None:
+    """For a full su(8) DLA every Lie-closure element is reached by the basis.
+    """
+    collection = p(["XX", "XY", "XZ", "YX"], n=3)
+    assert collection.get_algebra() == "su(8)"
+    basis = collection.get_algebra_basis()
+    embedded = _embedded_dla(collection, 3)
+    assert basis.shape[0] == embedded.shape[0] == collection.get_dla_dim()
+    assert all(_in_span(element, basis) for element in embedded)
+
+
+@pytest.mark.parametrize("n, label", [(3, "so(6)"), (4, "so(8)")])
+def test_nontrivial_so_reachability_via_majorana(n, label) -> None:
+    """For so(2n) the basis reaches every Lie-closure element, with a nontrivial correspondence.
+
+    The defining representation is ``2n x 2n`` while the embedding is ``2^n x 2^n``, so the
+    correspondence is nontrivial. The map ``E_ij - E_ji <-> (1/2) gamma_i gamma_j`` is an explicit
+    Lie isomorphism between the so(2n) basis and the Majorana bilinears, which span the embedded
+    DLA, so the basis reaches every element through it.
+    """
+    collection = p(["XX", "YY", "XY"], n=n)
+    assert collection.get_algebra() == label
+    basis = collection.get_algebra_basis()
+    gamma = _majorana_operators(n)
+    bilinears = np.array([0.5 * gamma[i] @ gamma[j] for i, j in combinations(range(2 * n), 2)])
+    assert np.allclose(_structure_constants(basis), _structure_constants(bilinears), atol=ATOL)
+    embedded = _embedded_dla(collection, n)
+    assert _spans_equal(bilinears, embedded)
+    assert all(_in_span(element, bilinears) for element in embedded)
+
+
+def test_compact_sp_reachability() -> None:
+    """The sp(4) basis is the compact form usp(8) and is a basis of the embedded DLA.
+
+    The flagship sp(4) DLA embeds as anti-Hermitian ``16 x 16`` operators while the defining rep
+    is ``8 x 8``. The basis is certified to be the compact real form (anti-Hermitian and
+    symplectic), and its dimension equals both get_dla_dim and the embedded Lie-closure
+    dimension, so it is a basis of that algebra.
+    """
+    collection = p(["XY", "XZ"], n=4)
+    assert collection.get_algebra() == "sp(4)"
+    basis = collection.get_algebra_basis()
+    form = symplectic_form(4)
+    assert basis.shape == (36, 8, 8)
+    assert _anti_hermitian(basis)
+    assert all(np.allclose(matrix, -form @ matrix.T @ form.T, atol=ATOL) for matrix in basis)
+    embedded = _embedded_dla(collection, 4)
+    assert _anti_hermitian(embedded)
+    assert basis.shape[0] == embedded.shape[0] == collection.get_dla_dim()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", ["a1", "a2", "a4", "a7", "a8", "a9", "a14", "a22", "b0", "b3"])
+def test_basis_matches_dla_dim_across_two_local_algebras(name) -> None:
+    """The basis dimension matches get_dla_dim across a spread of two-local algebras.
+    """
+    collection = p(G_LIE[name], n=3)
+    basis = collection.get_algebra_basis()
+    assert basis.shape[0] == collection.get_dla_dim()
+    assert _anti_hermitian(basis) and _independent(basis)
+
+
+def test_dropping_a_generator_changes_the_basis() -> None:
+    """The basis tracks the DLA: dropping a generator changes its dimension.
+    """
+    full = p(["XX", "YY", "XY"], n=3).get_algebra_basis()
+    reduced = p(["XX", "YY"], n=3).get_algebra_basis()
+    assert full.shape[0] != reduced.shape[0]


### PR DESCRIPTION
Closes #200. An alternative implementation (see also #223).

`get_algebra` returns a label; this adds `get_algebra_basis()` at the same level, returning the classified algebra as a concrete matrix basis in its defining representation.

## Approach
- **Compact real forms** (Wierichs et al. arXiv:2503.19014, Eq. 6-9): every generator is anti-Hermitian, so `exp` is unitary and the basis feeds the KAK pipeline.
  - `so(m)`: real antisymmetric.
  - `su(m)`: traceless anti-Hermitian, uniformly normalized `Tr(B†B)=2`.
  - `sp(m) = usp(2m)`: `{x in su(2m) : x = -J xᵀ Jᵀ}`, the compact symplectic form.
- **True direct sum**: summands embed block-diagonally into one basis of the complete operator (distinct blocks, full rank), not a stack of per-summand bases.
- **Dispatch from `Morph.get_algebra_properties()`** (no label-string parsing), mirroring the `get_dla_dim` loop, so the basis dimension equals `get_dla_dim` by construction. Mixed sums such as `u(1)+so(6)` work.
- Exposed as a method on `PauliStringCollection` and `Classification`.

## Reachability (the basis really reaches the DLA, element-wise)
Beyond bracket closure, the tests verify the basis spans the embedded Lie closure:
- **`so(6)` and `so(8)`**: explicit Lie isomorphism `E_ij - E_ji <-> (1/2) γ_i γ_j` (Majorana bilinears). The defining rep is strictly smaller than the embedding — a nontrivial correspondence — checked element-wise against the `get_algebra_basis()` output.
- **`su(8)`**: full `su`, every closure element reached directly.
- **`sp(4)`**: certified compact `usp(8)`, dimension tied to the embedded closure.

## Tests / CI
New `tests/test_algebra_basis.py` (constructor conditions, input validation, direct sum, dimension vs `get_dla_dim` across a `G_LIE` spread, the reachability proofs, and teeth). Full suite passes; `ruff`, `pylint` (10/10), `mypy`, and `sphinx-build -W` are green.

## Conventions
Basis ordering follows Wierichs Tab. II so the result is Cartan-decomposition ready. Documented in `src/paulie/common/algebra_basis.py` and `docs/source/user/classification.rst`.