### PR TITLE
Drop the bitarray leftovers from the pauliebits migration

### DIFF
--- a/src/paulie/common/pauli_string_bitarray.py
+++ b/src/paulie/common/pauli_string_bitarray.py
@@ -1,4 +1,4 @@
-"""Representation of a Pauli string as a bitarray."""
+"""Representation of a Pauli string as a bit vector."""
 from __future__ import annotations
 from collections.abc import Generator
 from typing import Self
@@ -411,9 +411,6 @@ class PauliString:
         if len(self) != len(other):
             raise ValueError("Pauli arrays must be of equal length")
         return self.bits.commutes_with(other.bits)
-        #px, pz = self.bits[::2], self.bits[1::2]
-        #qx, qz = other.bits[::2], other.bits[1::2]
-        #return (count_and(px, qz) + count_and(pz, qx)) % 2 == 0
 
     def get_substring(self, start: int, length: int = 1) -> PauliString:
         """
@@ -441,8 +438,6 @@ class PauliString:
 
         for i in range(0, 2*len(pauli_string)):
             self._bits[start * 2  + i] = pauli_string.bits[i]
-        # Invalidate cached bits
-        #self._bits = None
 
     def is_identity(self) -> bool:
         """

--- a/src/paulie/common/pauli_string_collection.py
+++ b/src/paulie/common/pauli_string_collection.py
@@ -325,8 +325,8 @@ class PauliStringCollection:
 
     def sort(self) -> Self:
         """
-        Sort the Pauli strings in the collection according to their bit value given by the bitarray
-        representation.
+        Sort the Pauli strings in the collection according to their bit value given by the
+        bit vector representation.
 
         Returns:
             Self

--- a/src/paulie/common/pauli_string_linear.py
+++ b/src/paulie/common/pauli_string_linear.py
@@ -1,5 +1,5 @@
 """
-Representation of a Pauli string as a bitarray.
+Representation of a linear combination of Pauli strings.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Three docstrings still described the Pauli string as a bitarray, a dependency the migration replaced. pauli_string_linear's module docstring was doubly wrong: it described a single Pauli string rather than a linear combination of them, which is what the module is for.

Also removes two blocks of commented-out code. The one in commutes_with is the pre-migration symplectic product, which would not run any more since count_and is no longer imported. The one in set_substring invalidates a bits cache that no longer exists; running it would blank the string instead.

