### PR TITLE
Fix PyPI release versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+      - name: Verify release version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          package_version="$(uv version --short)"
+          if [[ "${RELEASE_TAG}" != "v${package_version}" ]]; then
+            echo "::error::Release tag ${RELEASE_TAG} does not match package version v${package_version}"
+            exit 1
+          fi
       - name: Build
         run: uv build
+      - name: Validate distributions
+        run: uvx twine check dist/*
       - name: Upload dists
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paulie"
-version = "0.0.2"
+version = "0.2.2"
 description = "Classification of Pauli Lie algebras"
 authors = [
     {name = "Oxana Shaya"},
@@ -31,7 +31,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "scipy>=1.17.0",
     "intersphinx-registry>=0.2602.2",
-    "pauliebits",
+    "pauliebits>=0.0.1",
 ]
 
 [project.optional-dependencies]
@@ -122,6 +122,3 @@ disallow_incomplete_defs = true
 module = ["paulie.classifier.classification"]
 check_untyped_defs = true
 disallow_incomplete_defs = true
-
-[tool.uv.sources]
-pauliebits = { git = "https://github.com/QPauLie/pauliebits.git", branch = "master" }

--- a/uv.lock
+++ b/uv.lock
@@ -695,7 +695,7 @@ wheels = [
 
 [[package]]
 name = "paulie"
-version = "0.0.2"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "intersphinx-registry" },
@@ -736,7 +736,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
     { name = "networkx", specifier = ">=3.3" },
     { name = "numpy", specifier = ">=2.2.2" },
-    { name = "pauliebits", git = "https://github.com/QPauLie/pauliebits.git?branch=master" },
+    { name = "pauliebits", specifier = ">=0.0.1" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pydata-sphinx-theme", marker = "extra == 'dev'", specifier = ">=0.16.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
@@ -758,7 +758,20 @@ dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 [[package]]
 name = "pauliebits"
 version = "0.0.1"
-source = { git = "https://github.com/QPauLie/pauliebits.git?branch=master#e2f0a1b411ec8aace01a0205129f0f9284fd4235" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/83/ab268b3d35cb8d3e177621a569ba88d8f463c764de2149134bae1dd1222d/pauliebits-0.0.1.tar.gz", hash = "sha256:cc6688cd60129de81fb30393d14cf771d63ec9de33c6c07b6a1f4a108cb0e4a9", size = 168921, upload-time = "2026-09-01T10:00:01.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/a9/536b17374975a2fc13e36ad07fd4bad3b363320d9ef9861c7f57b231aa3c/pauliebits-0.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7dbbea4bf66b3bbe22d84d7b407728312ad07e69dd662a79f918578fdc97c05b", size = 216888, upload-time = "2026-09-01T09:59:37.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/14/54dcf5814c007e3a81ee3e6f994c21ba3ec5878a61a2f1f5d76e88bb66e8/pauliebits-0.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:230a564ebc6251f09d76d902317b5a40eb9f5b1d24f1453172c626e55cce5f9b", size = 215714, upload-time = "2026-09-01T09:59:38.54Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/a4/ae39543d27fb594c1ffbb4debd3a7f0b311f81c1758925676d8bfa11342e/pauliebits-0.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d3977ea3f3b4426f292af5b9a384bb3e2a72d2f812593380f6d6b41b0344a12", size = 430713, upload-time = "2026-09-01T09:59:39.994Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/da/071c157b29a5c43336349f21aeff29c04bd8fb63beab16bca1beccd5734e/pauliebits-0.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:082e3823a648b41055965ca0fdf16431f62eea1465beb833d64cf0a15d45e16b", size = 434873, upload-time = "2026-09-01T09:59:41.888Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/2b/b620fdfbf7b3ee4ed2ee754850f28bc6923b832ca0c6f99ee9c139540724/pauliebits-0.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:aff56cea9e56fa097a5f0bbf804ecac0eefd78f394ef796929aee8c48d0d3948", size = 216257, upload-time = "2026-09-01T09:59:43.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6b/a9808f4e4392eb164146942b902ebc7437ad1ca35715c6066b8bf9982632/pauliebits-0.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a35d50726c76b8967ed7064d6f2315a7aefa92a223e79e2de786e798afc42020", size = 216654, upload-time = "2026-09-01T09:59:45.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6a/aca3ea86048423ef7ed882c356eed764a2c4a4140c365b95a5c57dbc5db7/pauliebits-0.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cff708022553d39dc3d34327421e9d74eb820771ff3271c06d296958a5d1cee1", size = 215441, upload-time = "2026-09-01T09:59:46.558Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d0/02c0c0bad981db0c9782e4aea2a934eddf601f06706987d70d98cd862d42/pauliebits-0.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:637110a59bcbb5d25e7d7c5a6b699dc5919e20d8d6b20d4fc56a8855be5c2010", size = 428725, upload-time = "2026-09-01T09:59:48.381Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/1882b276347a366f940fb098a8d0f08d532e59f41686e8b9bce12afcce20/pauliebits-0.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dcfeed3b9ad156a93cf92a1c0691b1fdce490b2e24709f50284ecd02d881907b", size = 433154, upload-time = "2026-09-01T09:59:50.188Z" },
+    { url = "https://files.pythonhosted.org/packages/89/79/59f33eceb34c2061a65896b5f41dbe94a881fa9e9b3023d1fb56c66e294e/pauliebits-0.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:b7d871d6baec93a9e338e6978f8970beecfbfc608d72bf4a2c0240dea50b973c", size = 216080, upload-time = "2026-09-01T09:59:51.841Z" },
+]
 
 [[package]]
 name = "pillow"


### PR DESCRIPTION
## Summary

- bump the package version from 0.0.2 to 0.2.2 so PyPI receives a new immutable distribution
- require published pauliebits 0.0.1 or newer and resolve it from PyPI instead of mutable Git master
- reject GitHub release tags that do not match the package version
- validate built distributions with Twine before upload

## Verification

- 5,690 tests passed on Python 3.12
- Ruff passed
- Pylint rated 10.00/10
- MyPy passed
- wheel and source distribution passed Twine validation
- fresh wheel install resolved pauliebits 0.0.1 from PyPI and passed an import/IXYZ round-trip smoke test

This fixes the v0.2.1 publication failure where the release rebuilt the already-published paulie 0.0.2 files.